### PR TITLE
Improve maintainability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/build
 /.lake
 /lakefile.olean
 /lake-packages/*

--- a/CertifyingDatalog/Datalog/Database.lean
+++ b/CertifyingDatalog/Datalog/Database.lean
@@ -3,14 +3,11 @@ import CertifyingDatalog.Datalog.Basic
 import CertifyingDatalog.Datalog.Grounding
 import CertifyingDatalog.Datalog.Substitution
 
-class Database (τ: Signature) [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [DecidableEq τ.constants] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols] where
+class Database (τ: Signature) where
   contains: GroundAtom τ → Bool
 
-instance univDatabase (τ: Signature) [DecidableEq τ.vars] [DecidableEq τ.constants] [DecidableEq τ.relationSymbols] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
-: Database τ where
+instance univDatabase (τ: Signature) : Database τ where
   contains := fun _ => true
 
-instance emptyDatabase (τ: Signature) [DecidableEq τ.vars] [DecidableEq τ.constants] [DecidableEq τ.relationSymbols] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
-: Database τ where
+instance emptyDatabase (τ: Signature) : Database τ where
   contains := fun _ => false
-

--- a/CertifyingDatalog/Datalog/Grounding.lean
+++ b/CertifyingDatalog/Datalog/Grounding.lean
@@ -42,7 +42,7 @@ variable {τ: Signature}
 namespace GroundAtom
   def toAtom (ga: GroundAtom τ): Atom τ:= {symbol:=ga.symbol, atom_terms:= List.map Term.constant ga.atom_terms,term_length := by rw [List.length_map]; exact ga.term_length}
 
-  lemma eq_iff_toAtom_eq (a1 a2: GroundAtom τ): a1 = a2 ↔ a1.toAtom = a2.toAtom :=
+  lemma eq_iff_toAtom_eq {a1 a2: GroundAtom τ}: a1 = a2 ↔ a1.toAtom = a2.toAtom :=
   by
     constructor
     · intro h
@@ -63,7 +63,7 @@ namespace GroundAtom
   instance: Coe (GroundAtom τ) (Atom τ) where
     coe := GroundAtom.toAtom
 
-  lemma vars_empty (ga : GroundAtom τ) [DecidableEq τ.vars] : ga.toAtom.vars = ∅ := by
+  lemma vars_empty {ga : GroundAtom τ} [DecidableEq τ.vars] : ga.toAtom.vars = ∅ := by
     unfold toAtom
     unfold Atom.vars
     simp only
@@ -82,7 +82,7 @@ namespace Atom
     term_length := by simp; apply a.term_length
   }
 
-  lemma toGroundAtom_isSelf [DecidableEq τ.vars] (a: Atom τ) (h: a.vars = ∅): a = a.toGroundAtom h :=
+  lemma toGroundAtom_isSelf [DecidableEq τ.vars] {a: Atom τ} (h: a.vars = ∅): a = a.toGroundAtom h :=
   by
     unfold GroundAtom.toAtom
     unfold toGroundAtom
@@ -115,7 +115,7 @@ namespace GroundRule
     coe
       | r => r.toRule
 
-  lemma eq_iff_toRule_eq (r1 r2: GroundRule τ): r1 = r2 ↔ r1.toRule = r2.toRule :=
+  lemma eq_iff_toRule_eq {r1 r2: GroundRule τ} : r1 = r2 ↔ r1.toRule = r2.toRule :=
   by
     constructor
     · intro h
@@ -139,7 +139,7 @@ namespace GroundRule
 
   def bodySet [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] (r: GroundRule τ): Finset (GroundAtom τ) := List.toFinset r.body
 
-  lemma in_bodySet_iff_in_body [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] (r: GroundRule τ) : ∀ a, a ∈ r.body ↔ a ∈ r.bodySet := by simp [bodySet]
+  lemma in_bodySet_iff_in_body [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] {r: GroundRule τ} : ∀ a, a ∈ r.body ↔ a ∈ r.bodySet := by simp [bodySet]
 end GroundRule
 
 namespace Grounding
@@ -147,18 +147,18 @@ namespace Grounding
   | Term.constant c => Term.constant c
   | Term.variableDL v => Term.constant (g v)
 
-  lemma applyTerm_removesVars (g: Grounding τ) (t: Term τ): (g.applyTerm t).vars = ∅ := by
+  lemma applyTerm_removesVars {g: Grounding τ} {t: Term τ} : (g.applyTerm t).vars = ∅ := by
     cases t <;> (unfold applyTerm; unfold Term.vars; simp)
 
-  lemma applyTerm_preservesLength (g: Grounding τ) (a: Atom τ): (List.map g.applyTerm a.atom_terms).length = τ.relationArity a.symbol :=
+  lemma applyTerm_preservesLength {g: Grounding τ} {a: Atom τ}: (List.map g.applyTerm a.atom_terms).length = τ.relationArity a.symbol :=
   by
     rcases a with ⟨symbol, terms, term_length⟩
     simp only [List.length_map]
     rw [term_length]
 
-  def applyAtom (g: Grounding τ) (a: Atom τ): Atom τ := {symbol := a.symbol, atom_terms := List.map g.applyTerm a.atom_terms, term_length := applyTerm_preservesLength g a}
+  def applyAtom (g: Grounding τ) (a: Atom τ): Atom τ := {symbol := a.symbol, atom_terms := List.map g.applyTerm a.atom_terms, term_length := applyTerm_preservesLength}
 
-  lemma applyAtom_removesVars [DecidableEq τ.vars] (a: Atom τ) (g: Grounding τ): (g.applyAtom a).vars = ∅ :=
+  lemma applyAtom_removesVars [DecidableEq τ.vars] {a: Atom τ} {g: Grounding τ}: (g.applyAtom a).vars = ∅ :=
   by
     unfold applyAtom
     unfold Atom.vars
@@ -174,16 +174,16 @@ namespace Grounding
   | Term.constant c =>  c
   | Term.variableDL v => (g v)
 
-  lemma applyTerm'_on_constant_unchanged (g : Grounding τ) (c : τ.constants) : g.applyTerm' c = c := by unfold applyTerm'; simp
+  lemma applyTerm'_on_constant_unchanged {g : Grounding τ} {c : τ.constants} : g.applyTerm' c = c := by unfold applyTerm'; simp
 
-  lemma applyTerm'_preservesLength (g: Grounding τ) (a: Atom τ): (List.map g.applyTerm' a.atom_terms ).length = τ.relationArity a.symbol :=
+  lemma applyTerm'_preservesLength {g: Grounding τ} {a: Atom τ}: (List.map g.applyTerm' a.atom_terms ).length = τ.relationArity a.symbol :=
   by
     rw [List.length_map]
     apply a.term_length
 
-  def applyAtom' (g: Grounding τ) (a: Atom τ): GroundAtom τ := {symbol := a.symbol, atom_terms := List.map g.applyTerm' a.atom_terms, term_length := applyTerm'_preservesLength g a}
+  def applyAtom' (g: Grounding τ) (a: Atom τ): GroundAtom τ := {symbol := a.symbol, atom_terms := List.map g.applyTerm' a.atom_terms, term_length := applyTerm'_preservesLength}
 
-  lemma applyAtom'_on_GroundAtom_unchanged (g : Grounding τ) (ga : GroundAtom τ) : g.applyAtom' ga = ga := by
+  lemma applyAtom'_on_GroundAtom_unchanged {g : Grounding τ} {ga : GroundAtom τ} : g.applyAtom' ga = ga := by
     unfold applyAtom'
     rw [GroundAtom.ext_iff]
     simp only [GroundAtom.toAtom, List.map_map, true_and]
@@ -193,13 +193,13 @@ namespace Grounding
       simp only [List.get_eq_getElem, List.getElem_map, Function.comp_apply]
       rw [applyTerm'_on_constant_unchanged]
 
-  lemma applyAtom'_on_Atom_without_vars_unchanged [DecidableEq τ.vars] (g : Grounding τ) (a : Atom τ) (noVars : a.vars = ∅) : g.applyAtom' a = a := by
+  lemma applyAtom'_on_Atom_without_vars_unchanged [DecidableEq τ.vars] {g : Grounding τ} {a : Atom τ} (noVars : a.vars = ∅) : g.applyAtom' a = a := by
     rw [a.toGroundAtom_isSelf noVars]
     rw [applyAtom'_on_GroundAtom_unchanged]
 
   def applyRule (r: Rule τ) (g: Grounding τ): Rule τ := {head := g.applyAtom r.head, body := List.map g.applyAtom r.body }
 
-  lemma applyRule_removesVars [DecidableEq τ.vars] (r: Rule τ) (g: Grounding τ): (g.applyRule r).vars = ∅ := by
+  lemma applyRule_removesVars [DecidableEq τ.vars] {r: Rule τ} {g: Grounding τ}: (g.applyRule r).vars = ∅ := by
     unfold applyRule
     unfold Rule.vars
     simp only [Finset.union_eq_empty]

--- a/CertifyingDatalog/Datalog/Grounding.lean
+++ b/CertifyingDatalog/Datalog/Grounding.lean
@@ -2,22 +2,42 @@ import CertifyingDatalog.Basic
 import CertifyingDatalog.Datalog.Basic
 
 @[ext]
-structure GroundAtom (τ: Signature) [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [DecidableEq τ.constants] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
+structure GroundAtom (τ: Signature)
 where
   symbol: τ.relationSymbols
   atom_terms: List (τ.constants)
   term_length: atom_terms.length = τ.relationArity symbol
-  deriving DecidableEq, Hashable
+
+instance {τ: Signature} [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [DecidableEq τ.constants] : DecidableEq (GroundAtom τ) :=
+  fun l r =>
+    if h: l.symbol = r.symbol
+    then
+      if h': l.atom_terms = r.atom_terms
+      then isTrue (by ext; exact h; simp [h'])
+      else isFalse (by by_contra p; rw[p] at h'; contradiction)
+    else isFalse (by by_contra p; rw[p] at h; contradiction)
+
+instance {τ: Signature} [Hashable τ.vars] [Hashable τ.relationSymbols] [Hashable τ.constants] : Hashable (GroundAtom τ) where
+  hash :=
+    fun a => mixHash (hash a.symbol) (hash a.atom_terms)
 
 @[ext]
-structure GroundRule (τ: Signature) [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [DecidableEq τ.constants] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols] where
+structure GroundRule (τ: Signature) where
   head: GroundAtom τ
   body: List (GroundAtom τ)
-  deriving DecidableEq
+
+instance {τ: Signature} [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [DecidableEq τ.constants] : DecidableEq (GroundRule τ) :=
+  fun l r =>
+    if h:l.head = r.head
+    then
+      if h':l.body = r.body
+      then isTrue (by ext; rw[h]; rw[h]; rw[h'])
+      else isFalse (by by_contra p; rw [p] at h'; contradiction)
+    else isFalse (by by_contra p; rw[p] at h; contradiction)
 
 abbrev Grounding (τ: Signature) := τ.vars → τ.constants
 
-variable {τ: Signature} [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [DecidableEq τ.constants] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
+variable {τ: Signature}
 
 namespace GroundAtom
   def toAtom (ga: GroundAtom τ): Atom τ:= {symbol:=ga.symbol, atom_terms:= List.map Term.constant ga.atom_terms,term_length := by rw [List.length_map]; exact ga.term_length}
@@ -25,67 +45,64 @@ namespace GroundAtom
   lemma eq_iff_toAtom_eq (a1 a2: GroundAtom τ): a1 = a2 ↔ a1.toAtom = a2.toAtom :=
   by
     constructor
-    intro h
-    rw [h]
-
-    unfold GroundAtom.toAtom
-    simp
-    intros sym terms
-    rw [GroundAtom.ext_iff]
-    constructor
-    apply sym
-    have : Function.Injective (List.map (Term.constant (τ := τ))) := by
-      rw [List.map_injective_iff]
-      intro _ _ term_eq
-      injection term_eq
-    apply this
-    exact terms
+    · intro h
+      rw [h]
+    · unfold GroundAtom.toAtom
+      simp only [Atom.mk.injEq, and_imp]
+      intros sym terms
+      rw [GroundAtom.ext_iff]
+      constructor
+      · apply sym
+      · have : Function.Injective (List.map (Term.constant (τ := τ))) := by
+          rw [List.map_injective_iff]
+          intro _ _ term_eq
+          injection term_eq
+        apply this
+        exact terms
 
   instance: Coe (GroundAtom τ) (Atom τ) where
     coe := GroundAtom.toAtom
 
-  lemma vars_empty (ga : GroundAtom τ) : ga.toAtom.vars = ∅ := by
+  lemma vars_empty (ga : GroundAtom τ) [DecidableEq τ.vars] : ga.toAtom.vars = ∅ := by
     unfold toAtom
     unfold Atom.vars
-    simp
+    simp only
     rw [List.foldl_union_empty]
-    simp
+    simp only [List.mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂, true_and]
     intro _ _
     unfold Term.vars
     simp
 end GroundAtom
 
 namespace Atom
-  def toGroundAtom (a: Atom τ) (h: a.vars = ∅): GroundAtom τ :=
+  def toGroundAtom (a: Atom τ) [DecidableEq τ.vars] (h: a.vars = ∅) : GroundAtom τ :=
   {
     symbol:= a.symbol,
     atom_terms := List.map (fun ⟨t, t_in_a⟩ => t.toConstant (a.vars_empty_iff.mp h t t_in_a)) a.atom_terms.attach,
     term_length := by simp; apply a.term_length
   }
 
-  lemma toGroundAtom_isSelf (a: Atom τ) (h: a.vars = ∅): a = a.toGroundAtom h :=
+  lemma toGroundAtom_isSelf [DecidableEq τ.vars] (a: Atom τ) (h: a.vars = ∅): a = a.toGroundAtom h :=
   by
     unfold GroundAtom.toAtom
     unfold toGroundAtom
-    simp
+    simp only [List.map_map]
     rw [Atom.ext_iff]
-    simp
+    simp only [true_and]
     rw [vars_empty_iff] at h
-
     apply List.ext_get
-    simp
-    intro n h1 h2
-    simp
-
-    have h': ∀ (t : Term τ) (noVars : t.vars = ∅), t = t.toConstant noVars := by
-      intro t noVars
-      unfold Term.toConstant
-      cases t with
-      | constant c => simp
-      | variableDL v =>
-        unfold Term.vars at noVars
-        simp at noVars
-    apply h'
+    · simp
+    · intro n h1 h2
+      simp only [List.get_eq_getElem, List.getElem_map, List.getElem_attach, Function.comp_apply]
+      have h': ∀ (t : Term τ) (noVars : t.vars = ∅), t = t.toConstant noVars := by
+        intro t noVars
+        unfold Term.toConstant
+        cases t with
+        | constant c => simp
+        | variableDL v =>
+          unfold Term.vars at noVars
+          simp at noVars
+      apply h'
 end Atom
 
 namespace GroundRule
@@ -101,29 +118,28 @@ namespace GroundRule
   lemma eq_iff_toRule_eq (r1 r2: GroundRule τ): r1 = r2 ↔ r1.toRule = r2.toRule :=
   by
     constructor
-    intro h
-    rw [h]
+    · intro h
+      rw [h]
+    · unfold GroundRule.toRule
+      rw [GroundRule.ext_iff]
+      intro h
+      simp only [Rule.mk.injEq] at h
+      rcases h with ⟨head_eq, body_eq⟩
+      have inj_toAtom: Function.Injective (GroundAtom.toAtom (τ:= τ)) := by
+        unfold Function.Injective
+        intros a1 a2 h
+        rw [GroundAtom.eq_iff_toAtom_eq]
+        apply h
+      constructor
+      · unfold Function.Injective at inj_toAtom
+        apply inj_toAtom head_eq
+      · rw [← List.map_injective_iff] at inj_toAtom
+        apply inj_toAtom
+        exact body_eq
 
-    unfold GroundRule.toRule
-    rw [GroundRule.ext_iff]
-    intro h
-    simp at h
-    rcases h with ⟨head_eq, body_eq⟩
-    have inj_toAtom: Function.Injective (GroundAtom.toAtom (τ:= τ)) := by
-      unfold Function.Injective
-      intros a1 a2 h
-      rw [GroundAtom.eq_iff_toAtom_eq]
-      apply h
-    constructor
-    unfold Function.Injective at inj_toAtom
-    apply inj_toAtom head_eq
-    rw [← List.map_injective_iff] at inj_toAtom
-    apply inj_toAtom
-    exact body_eq
+  def bodySet [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] (r: GroundRule τ): Finset (GroundAtom τ) := List.toFinset r.body
 
-  def bodySet (r: GroundRule τ): Finset (GroundAtom τ) := List.toFinset r.body
-
-  lemma in_bodySet_iff_in_body (r: GroundRule τ) : ∀ a, a ∈ r.body ↔ a ∈ r.bodySet := by simp [bodySet]
+  lemma in_bodySet_iff_in_body [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] (r: GroundRule τ) : ∀ a, a ∈ r.body ↔ a ∈ r.bodySet := by simp [bodySet]
 end GroundRule
 
 namespace Grounding
@@ -137,18 +153,18 @@ namespace Grounding
   lemma applyTerm_preservesLength (g: Grounding τ) (a: Atom τ): (List.map g.applyTerm a.atom_terms).length = τ.relationArity a.symbol :=
   by
     rcases a with ⟨symbol, terms, term_length⟩
-    simp
+    simp only [List.length_map]
     rw [term_length]
 
   def applyAtom (g: Grounding τ) (a: Atom τ): Atom τ := {symbol := a.symbol, atom_terms := List.map g.applyTerm a.atom_terms, term_length := applyTerm_preservesLength g a}
 
-  lemma applyAtom_removesVars (a: Atom τ) (g: Grounding τ): (g.applyAtom a).vars = ∅ :=
+  lemma applyAtom_removesVars [DecidableEq τ.vars] (a: Atom τ) (g: Grounding τ): (g.applyAtom a).vars = ∅ :=
   by
     unfold applyAtom
     unfold Atom.vars
-    simp
+    simp only
     rw [List.foldl_union_empty]
-    simp
+    simp only [List.mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂, true_and]
     intro x _
     unfold Term.vars
     unfold applyTerm
@@ -170,27 +186,27 @@ namespace Grounding
   lemma applyAtom'_on_GroundAtom_unchanged (g : Grounding τ) (ga : GroundAtom τ) : g.applyAtom' ga = ga := by
     unfold applyAtom'
     rw [GroundAtom.ext_iff]
-    simp [GroundAtom.toAtom]
+    simp only [GroundAtom.toAtom, List.map_map, true_and]
     apply List.ext_get
     · rw [List.length_map]
     · intro _ _ _
-      simp
+      simp only [List.get_eq_getElem, List.getElem_map, Function.comp_apply]
       rw [applyTerm'_on_constant_unchanged]
 
-  lemma applyAtom'_on_Atom_without_vars_unchanged (g : Grounding τ) (a : Atom τ) (noVars : a.vars = ∅) : g.applyAtom' a = a := by
+  lemma applyAtom'_on_Atom_without_vars_unchanged [DecidableEq τ.vars] (g : Grounding τ) (a : Atom τ) (noVars : a.vars = ∅) : g.applyAtom' a = a := by
     rw [a.toGroundAtom_isSelf noVars]
     rw [applyAtom'_on_GroundAtom_unchanged]
 
   def applyRule (r: Rule τ) (g: Grounding τ): Rule τ := {head := g.applyAtom r.head, body := List.map g.applyAtom r.body }
 
-  lemma applyRule_removesVars (r: Rule τ) (g: Grounding τ): (g.applyRule r).vars = ∅ := by
+  lemma applyRule_removesVars [DecidableEq τ.vars] (r: Rule τ) (g: Grounding τ): (g.applyRule r).vars = ∅ := by
     unfold applyRule
     unfold Rule.vars
-    simp
+    simp only [Finset.union_eq_empty]
     rw [applyAtom_removesVars]
-    simp
+    simp only [true_and]
     rw [List.foldl_union_empty]
-    simp
+    simp only [List.mem_map, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂, true_and]
     intro a _
     apply applyAtom_removesVars
 

--- a/CertifyingDatalog/Datalog/Substitution.lean
+++ b/CertifyingDatalog/Datalog/Substitution.lean
@@ -30,7 +30,7 @@ namespace Substitution
     apply Eq.symm
     apply subs
     unfold domain
-    simp
+    simp only [Set.mem_setOf_eq]
     rw [h]
     simp
 
@@ -46,7 +46,7 @@ namespace Substitution
       have s1_s2: s1 v = s2 v := by
         apply subs
         unfold domain
-        simp
+        simp only [Set.mem_setOf_eq]
         rw [q]
         simp
       rw [s1_s2] at p
@@ -76,7 +76,7 @@ namespace Substitution
     rw [subs_l]
     apply subs_r
     unfold domain
-    simp
+    simp only [Set.mem_setOf_eq]
     rw [← subs_l]
     unfold domain at h
     simp at h
@@ -84,9 +84,8 @@ namespace Substitution
 
 end Substitution
 
-
 namespace Substitution
-  variable {τ: Signature} [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [DecidableEq τ.constants] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
+  variable {τ: Signature}
 
   def applyTerm (s: Substitution τ) : Term τ -> Term τ
   | Term.constant c => Term.constant c
@@ -94,13 +93,13 @@ namespace Substitution
     | .some c => Term.constant c
     | .none => Term.variableDL v
 
-  lemma applyTerm_preservesLength (s: Substitution τ) (a: Atom τ): (List.map s.applyTerm a.atom_terms ).length = τ.relationArity a.symbol :=
+  lemma applyTerm_preservesLength {s: Substitution τ} {a: Atom τ}: (List.map s.applyTerm a.atom_terms ).length = τ.relationArity a.symbol :=
   by
     rw [List.length_map]
     apply a.term_length
 
   def applyAtom (s: Substitution τ) (a: Atom τ) : Atom τ :=
-    {symbol := a.symbol, atom_terms := List.map s.applyTerm a.atom_terms, term_length := s.applyTerm_preservesLength a}
+    {symbol := a.symbol, atom_terms := List.map s.applyTerm a.atom_terms, term_length := s.applyTerm_preservesLength}
 
   def applyRule (s: Substitution τ) (r: Rule τ) : Rule τ := {head := s.applyAtom r.head, body := List.map s.applyAtom r.body}
 
@@ -108,36 +107,35 @@ namespace Substitution
   by
     intro v
     constructor
-    intro h
-    unfold domain at h
-    rw [Set.mem_setOf] at h
-    rw [Option.isSome_iff_exists] at h
-    rcases h with ⟨c, c_prop⟩
-    exists c
-    simp [applyTerm, c_prop]
+    · intro h
+      unfold domain at h
+      rw [Set.mem_setOf] at h
+      rw [Option.isSome_iff_exists] at h
+      rcases h with ⟨c, c_prop⟩
+      exists c
+      simp only [applyTerm, c_prop]
+    · intro h
+      rcases h with ⟨c, c_prop⟩
+      unfold applyTerm at c_prop
+      simp only at c_prop
+      by_cases p: Option.isSome (s v) = true
+      · unfold domain
+        rw [Set.mem_setOf]
+        apply p
+      · simp only [Bool.not_eq_true, Option.not_isSome, Option.isNone_iff_eq_none] at p
+        simp [p] at c_prop
 
-    intro h
-    rcases h with ⟨c, c_prop⟩
-    unfold applyTerm at c_prop
-    simp at c_prop
-    by_cases p: Option.isSome (s v) = true
-    · unfold domain
-      rw [Set.mem_setOf]
-      apply p
-    · simp at p
-      simp [p] at c_prop
-
-  lemma applyAtom_isGround_impl_varsSubsetDomain {a: Atom τ} {s: Substitution τ} (subs_ground: ∃ (a': GroundAtom τ), s.applyAtom a = a'): ↑ a.vars ⊆ s.domain :=
+  lemma applyAtom_isGround_impl_varsSubsetDomain [DecidableEq τ.vars] {a: Atom τ} {s: Substitution τ} (subs_ground: ∃ (a': GroundAtom τ), s.applyAtom a = a'): ↑ a.vars ⊆ s.domain :=
   by
     unfold Atom.vars
     rcases subs_ground with ⟨a', a'_prop⟩
     unfold applyAtom at a'_prop
     unfold GroundAtom.toAtom at a'_prop
     rw [Atom.ext_iff] at a'_prop
-    simp at a'_prop
+    simp only at a'_prop
     rcases a'_prop with ⟨_, terms_eq⟩
     rw [List.foldl_union_subset_set]
-    simp
+    simp only [Finset.coe_empty, Set.empty_subset, true_and]
 
     intros t t_mem
     cases t with
@@ -146,7 +144,7 @@ namespace Substitution
       simp
     | variableDL v =>
       unfold Term.vars
-      simp
+      simp only [Finset.coe_singleton, Set.singleton_subset_iff]
       rw [varInDom_iff]
       rw [List.mem_iff_get] at t_mem
       rcases t_mem with ⟨v_pos, v_pos_proof⟩
@@ -157,63 +155,62 @@ namespace Substitution
         apply v_pos_a
       use List.get a'.atom_terms {val:= v_pos, isLt:= v_pos_a'}
       have get_of_terms_eq := List.get_of_eq terms_eq ⟨v_pos, by rw [List.length_map]; exact v_pos_a⟩
-      simp at get_of_terms_eq
-      simp
+      simp only [List.get_eq_getElem, List.getElem_map] at get_of_terms_eq
+      simp only [List.get_eq_getElem]
       rw [get_of_terms_eq]
 
-  lemma applyRule_isGround_impl_varsSubsetDomain {r: Rule τ} {s: Substitution τ} (subs_ground: ∃ (r': GroundRule τ), s.applyRule r = r'): ↑ r.vars ⊆ s.domain :=
+  lemma applyRule_isGround_impl_varsSubsetDomain [DecidableEq τ.vars] {r: Rule τ} {s: Substitution τ} (subs_ground: ∃ (r': GroundRule τ), s.applyRule r = r'): ↑ r.vars ⊆ s.domain :=
   by
     unfold Rule.vars
-    simp at subs_ground
+    simp only at subs_ground
     rcases subs_ground with ⟨r', r'_prop⟩
     unfold applyRule at r'_prop
     rw [Rule.ext_iff] at r'_prop
-    simp at r'_prop
+    simp only at r'_prop
     rcases r'_prop with ⟨left,right⟩
-    simp
+    simp only [Finset.coe_union, Set.union_subset_iff]
     constructor
-    apply applyAtom_isGround_impl_varsSubsetDomain
-    use r'.head
-    rw [left]
-    unfold GroundRule.toRule
-    simp
-
-    rw [List.foldl_union_subset_set]
-    simp
-    intros a a_mem
-    apply applyAtom_isGround_impl_varsSubsetDomain
-    unfold GroundRule.toRule at right
-    simp at right
-    rw [List.mem_iff_get] at a_mem
-    rcases a_mem with ⟨a_pos, pos_prop⟩
-    rcases a_pos with ⟨a_pos, a_pos_proof⟩
-    have a_pos_proof': a_pos < List.length r'.body := by
-      rw [← List.length_map r'.body GroundAtom.toAtom, ← right, List.length_map r.body]
-      apply a_pos_proof
-    use List.get r'.body (Fin.mk a_pos a_pos_proof')
-    rw [← pos_prop]
-    have h: a_pos < (List.map s.applyAtom r.body ).length := by
-      rw [List.length_map]
-      apply a_pos_proof
-    have get_of_right := List.get_of_eq right ⟨a_pos, h⟩
-    simp at get_of_right
-    simp
-    rw [get_of_right]
+    · apply applyAtom_isGround_impl_varsSubsetDomain
+      use r'.head
+      rw [left]
+      unfold GroundRule.toRule
+      simp
+    · rw [List.foldl_union_subset_set]
+      simp only [Finset.coe_empty, Set.empty_subset, true_and]
+      intros a a_mem
+      apply applyAtom_isGround_impl_varsSubsetDomain
+      unfold GroundRule.toRule at right
+      simp only at right
+      rw [List.mem_iff_get] at a_mem
+      rcases a_mem with ⟨a_pos, pos_prop⟩
+      rcases a_pos with ⟨a_pos, a_pos_proof⟩
+      have a_pos_proof': a_pos < List.length r'.body := by
+        rw [← List.length_map r'.body GroundAtom.toAtom, ← right, List.length_map r.body]
+        apply a_pos_proof
+      use List.get r'.body (Fin.mk a_pos a_pos_proof')
+      rw [← pos_prop]
+      have h: a_pos < (List.map s.applyAtom r.body ).length := by
+        rw [List.length_map]
+        apply a_pos_proof
+      have get_of_right := List.get_of_eq right ⟨a_pos, h⟩
+      simp only [List.get_eq_getElem, List.getElem_map] at get_of_right
+      simp only [List.get_eq_getElem]
+      rw [get_of_right]
 
   def toGrounding [ex: Inhabited τ.constants] (s: Substitution τ): Grounding τ := fun t => match s t with
     | .some c => c
     | .none => ex.default
 
-  lemma toGrounding_applyTerm_eq [Inhabited τ.constants] (t: Term τ) (s: Substitution τ) (h: ↑ t.vars ⊆ s.domain): Term.constant (s.toGrounding.applyTerm' t) = s.applyTerm t := by
+  lemma toGrounding_applyTerm_eq [Inhabited τ.constants] {t: Term τ} {s: Substitution τ} (h: ↑ t.vars ⊆ s.domain): Term.constant (s.toGrounding.applyTerm' t) = s.applyTerm t := by
     unfold toGrounding
     unfold Grounding.applyTerm'
     unfold applyTerm
-    simp
+    simp only
     cases t with
     | constant c =>
       simp
     | variableDL v =>
-      simp
+      simp only
       cases eq : s v with
       | some c => simp
       | none =>
@@ -222,57 +219,57 @@ namespace Substitution
         unfold Option.isSome at h
         simp [eq] at h
 
-  lemma toGrounding_applyAtom_eq [Inhabited τ.constants] (a: Atom τ) (s: Substitution τ) (h: ↑ a.vars ⊆ s.domain): (s.toGrounding.applyAtom' a).toAtom = s.applyAtom a := by
+  lemma toGrounding_applyAtom_eq [DecidableEq τ.vars] [Inhabited τ.constants] {a: Atom τ} {s: Substitution τ} (h: ↑ a.vars ⊆ s.domain): (s.toGrounding.applyAtom' a).toAtom = s.applyAtom a := by
     unfold Grounding.applyAtom'
     unfold GroundAtom.toAtom
     unfold applyAtom
     rw [Atom.ext_iff]
-    simp
+    simp only [List.map_map, List.map_inj_left, Function.comp_apply, true_and]
     intro n h'
     apply toGrounding_applyTerm_eq
     apply Atom.vars_subset_impl_term_vars_subset
     exact h'
     exact h
 
-  lemma toGrounding_applyRule_eq [Inhabited τ.constants] (r: Rule τ) (s: Substitution τ) (h: ↑ r.vars ⊆ s.domain): (s.toGrounding.applyRule' r).toRule = s.applyRule r := by
+  lemma toGrounding_applyRule_eq [DecidableEq τ.vars] [Inhabited τ.constants] {r: Rule τ} {s: Substitution τ} (h: ↑ r.vars ⊆ s.domain): (s.toGrounding.applyRule' r).toRule = s.applyRule r := by
     unfold GroundRule.toRule
     unfold Grounding.applyRule'
     unfold Substitution.applyRule
     rw [Rule.ext_iff]
-    simp
+    simp only [List.map_map, List.map_inj_left, Function.comp_apply]
     constructor
-    apply toGrounding_applyAtom_eq
-    apply Rule.vars_subset_impl_atom_vars_subset (a:=r.head) (r:=r)
-    left
-    rfl
-    apply h
-    intro n h'
-    apply toGrounding_applyAtom_eq
-    apply Rule.vars_subset_impl_atom_vars_subset (r:=r)
-    right
-    exact h'
-    exact h
+    · apply toGrounding_applyAtom_eq
+      apply Rule.vars_subset_impl_atom_vars_subset (a:=r.head) (r:=r)
+      · left
+        rfl
+      · apply h
+    · intro n h'
+      apply toGrounding_applyAtom_eq
+      apply Rule.vars_subset_impl_atom_vars_subset (r:=r)
+      · right
+        exact h'
+      · exact h
 
   lemma subset_applyTerm_eq {s1 s2: Substitution τ} {t: Term τ} {c: τ.constants} (subs: s1 ⊆ s2) (eq: s1.applyTerm t = c): s2.applyTerm t = c := by
     cases t with
     | constant c' =>
       unfold applyTerm
-      simp
+      simp only [Term.constant.injEq]
       unfold applyTerm at eq
-      simp at eq
+      simp only [Term.constant.injEq] at eq
       apply eq
     | variableDL v =>
       unfold applyTerm at *
-      simp at *
+      simp only at *
       cases eq2 : s1 v with
       | none => rw [eq2] at eq; simp at eq
       | some c =>
         rw [eq2] at eq
-        simp at eq
+        simp only [Term.constant.injEq] at eq
         have s2_v: s2 v = some c := by
           apply subset_some s1 s2 subs
           exact eq2
-        simp [s2_v]
+        simp only [s2_v, Term.constant.injEq]
         exact eq
 
   lemma subset_applyTermList_eq {s1 s2: Substitution τ} {l1: List (Term τ)} {l2: List (τ.constants)} (subs: s1 ⊆ s2) (eq: List.map s1.applyTerm l1 = List.map Term.constant l2): List.map s2.applyTerm l1 = List.map Term.constant l2 := by
@@ -288,125 +285,120 @@ namespace Substitution
       | nil =>
         simp at eq
       | cons hd' tl' =>
-        simp at eq
+        simp only [List.map_cons, List.cons.injEq] at eq
         rcases eq with ⟨left,right⟩
-        simp
+        simp only [List.map_cons, List.cons.injEq]
         constructor
-        apply subset_applyTerm_eq subs left
-        apply ih
-        apply right
+        · apply subset_applyTerm_eq subs left
+        · apply ih
+          apply right
 
   lemma subset_applyAtom_eq {s1 s2: Substitution τ} {a: Atom τ} {ga: GroundAtom τ} (subs: s1 ⊆ s2) (eq: s1.applyAtom a = ga): s2.applyAtom a = ga := by
     unfold applyAtom at *
     unfold GroundAtom.toAtom at *
-    simp at *
+    simp only [Atom.mk.injEq] at *
     rcases eq with ⟨left,right⟩
     constructor
-    apply left
-    apply subset_applyTermList_eq subs right
+    · apply left
+    · apply subset_applyTermList_eq subs right
 
-  lemma applyTerm_remainingVarsNotInDomain (t: Term τ) (s: Substitution τ): (s.applyTerm t).vars = t.vars.filter_nc (fun x => ¬ x ∈ s.domain) := by
+  lemma applyTerm_remainingVarsNotInDomain {t: Term τ} {s: Substitution τ}: (s.applyTerm t).vars = t.vars.filter_nc (fun x => ¬ x ∈ s.domain) := by
     cases t with
     | constant c =>
       unfold applyTerm
       unfold Term.vars
       rw [Finset.ext_iff]
-      simp
+      simp only [Finset.not_mem_empty, false_iff]
       simp [Finset.mem_filter_nc]
     | variableDL v =>
       unfold applyTerm
       unfold Term.vars
       rw [Finset.ext_iff]
-      simp
-
+      simp only
       cases eq : s v with
       | some c =>
-        simp
+        simp only [Finset.not_mem_empty, false_iff]
         intro v'
-        simp [Finset.mem_filter_nc]
+        simp only [Finset.mem_filter_nc, Finset.mem_singleton, not_and]
         unfold domain
-        simp
+        simp only [Set.mem_setOf_eq, Bool.not_eq_true, Option.not_isSome, Option.isNone_iff_eq_none]
         intro h' p
         rw [p] at h'
         rw [eq] at h'
         contradiction
       | none =>
-        simp
+        simp only [Finset.mem_singleton]
         intro v'
-        simp [Finset.mem_filter_nc]
+        simp only [Finset.mem_filter_nc, Finset.mem_singleton, iff_and_self]
         intro h'
         unfold domain
-        simp
+        simp only [Set.mem_setOf_eq, Bool.not_eq_true, Option.not_isSome, Option.isNone_iff_eq_none]
         rw [h', eq]
 
-  lemma applyAtom_remainingVarsNotInDomain (a: Atom τ) (s: Substitution τ): (s.applyAtom a).vars = a.vars.filter_nc (fun x => ¬ x ∈ s.domain)  := by
+  lemma applyAtom_remainingVarsNotInDomain [DecidableEq τ.vars] {a: Atom τ} {s: Substitution τ}: (s.applyAtom a).vars = a.vars.filter_nc (fun x => ¬ x ∈ s.domain)  := by
     apply Finset.ext
     intro v
     unfold Atom.vars
     rw [List.mem_foldl_union, Finset.mem_filter_nc, List.mem_foldl_union]
-    simp
+    simp only [Finset.not_mem_empty, false_or]
     unfold applyAtom
-    simp
+    simp only [List.mem_map, exists_exists_and_eq_and]
     simp_rw [applyTerm_remainingVarsNotInDomain, Finset.mem_filter_nc]
     tauto
 end Substitution
 
 namespace Grounding
-  variable {τ: Signature} [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [DecidableEq τ.constants] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
+  variable {τ: Signature}
 
   def toSubstitution (g: Grounding τ): Substitution τ := fun t => Option.some (g t)
 
-  lemma toSubsitution_applyTerm_eq (g: Grounding τ) (t: Term τ): g.applyTerm' t = g.toSubstitution.applyTerm t := by
+  lemma toSubsitution_applyTerm_eq {g: Grounding τ} {t: Term τ}: g.applyTerm' t = g.toSubstitution.applyTerm t := by
     unfold applyTerm'
     unfold toSubstitution
     unfold Substitution.applyTerm
     cases t <;> simp
 
-  lemma toSubsitution_applyAtom_eq (a: Atom τ) (g: Grounding τ): g.applyAtom' a = g.toSubstitution.applyAtom a := by
+  lemma toSubsitution_applyAtom_eq {a: Atom τ} {g: Grounding τ}: g.applyAtom' a = g.toSubstitution.applyAtom a := by
     rw [Atom.ext_iff]
     unfold applyAtom'
     unfold Substitution.applyAtom
-    simp
+    simp only
     constructor
-    unfold GroundAtom.toAtom
-    simp
+    · unfold GroundAtom.toAtom
+      simp
+    · unfold GroundAtom.toAtom
+      simp only [List.map_map, List.map_inj_left, Function.comp_apply]
+      intros
+      rw [toSubsitution_applyTerm_eq]
 
-    unfold GroundAtom.toAtom
-    simp
-    intros
-    rw [toSubsitution_applyTerm_eq]
-
-  lemma toSubsitution_applyRule_eq (r: Rule τ) (g: Grounding τ): g.applyRule' r = g.toSubstitution.applyRule r := by
-    simp
+  lemma toSubsitution_applyRule_eq {r: Rule τ} {g: Grounding τ} : g.applyRule' r = g.toSubstitution.applyRule r := by
+    simp only
     unfold applyRule'
     unfold Substitution.applyRule
     unfold GroundRule.toRule
     rw [Rule.ext_iff]
     constructor
-    simp
-    apply toSubsitution_applyAtom_eq
-
-    simp
-    intros
-    rw [toSubsitution_applyAtom_eq]
+    · simp only
+      apply toSubsitution_applyAtom_eq
+    · simp only [List.map_map, List.map_inj_left, Function.comp_apply]
+      intros
+      rw [toSubsitution_applyAtom_eq]
 end Grounding
 
-theorem grounding_substitution_equiv {τ: Signature} [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [DecidableEq τ.constants] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols] [Inhabited τ.constants] (r: GroundRule τ) (r': Rule τ): (∃ (g: Grounding τ), g.applyRule' r' = r) ↔ (∃ (s: Substitution τ), s.applyRule r'= r) :=
+theorem grounding_substitution_equiv {τ: Signature} [DecidableEq τ.vars] [Inhabited τ.constants] {r: GroundRule τ} {r': Rule τ}: (∃ (g: Grounding τ), g.applyRule' r' = r) ↔ (∃ (s: Substitution τ), s.applyRule r'= r) :=
   by
-    simp
+    simp only
     constructor
-    intro h
-    rcases h with ⟨g, g_prop⟩
-    use g.toSubstitution
-    rw [← g_prop]
-    simp [Grounding.toSubsitution_applyRule_eq]
-
-    intro h
-    rcases h with ⟨s, s_prop⟩
-    use s.toGrounding
-    rw [GroundRule.eq_iff_toRule_eq]
-    rw [← s_prop]
-    apply Substitution.toGrounding_applyRule_eq
-    apply Substitution.applyRule_isGround_impl_varsSubsetDomain
-    use r
-
+    · intro h
+      rcases h with ⟨g, g_prop⟩
+      use g.toSubstitution
+      rw [← g_prop]
+      simp [Grounding.toSubsitution_applyRule_eq]
+    · intro h
+      rcases h with ⟨s, s_prop⟩
+      use s.toGrounding
+      rw [GroundRule.eq_iff_toRule_eq]
+      rw [← s_prop]
+      apply Substitution.toGrounding_applyRule_eq
+      apply Substitution.applyRule_isGround_impl_varsSubsetDomain
+      use r

--- a/CertifyingDatalog/Datastructures/Array.lean
+++ b/CertifyingDatalog/Datastructures/Array.lean
@@ -2,7 +2,7 @@ import CertifyingDatalog.Datastructures.List
 
 namespace Array
 
-  lemma mem_iff_get (a:A) (as: Array A): a ∈ as ↔ ∃ i : Fin as.size, as[i] = a := by
+  lemma mem_iff_get {a:A} {as: Array A}: a ∈ as ↔ ∃ i : Fin as.size, as[i] = a := by
     rw [mem_def, List.mem_iff_get]
     constructor
     · intro h
@@ -13,62 +13,4 @@ namespace Array
       rcases h with ⟨i, get_i⟩
       use i
       exact get_i
-
-  lemma get_set_not_eq (as: Array A) (i: Fin as.size) (j : Nat) (hj : j < as.size) (v : A) (i_j: ¬ j = i.val): (as.set i v)[j]'(by simp [*]) = as[j] := by
-    rw [get_set]
-    simp
-    intro h
-    simp_rw[h] at i_j
-    simp at i_j
-    exact hj
-
-  lemma mem_iff_exists (as: Array A) (a:A): a ∈ as ↔ ∃ (i: Fin as.size), a = as[i] :=
-  by
-    cases as with
-    | mk l  =>
-      rw [mem_def]
-      simp
-      rw [List.mem_iff_get]
-      constructor
-      intro h
-      rcases h with ⟨n, get_n⟩
-      use n
-      apply Eq.symm
-      apply get_n
-
-      intro h
-      rcases h with ⟨i, get_i⟩
-      use i
-      apply Eq.symm
-      apply get_i
-
-  lemma mem_set_iff (as: Array A) (i: Fin as.size) (a d: A): a ∈ as.set i d ↔ a = d ∨ ∃ (j: Fin as.size), j ≠ i ∧ a = as[j] :=
-  by
-    cases as with
-    | mk data =>
-      unfold set
-      rw [mem_def]
-      simp
-      rw [List.mem_set_iff]
-      tauto
-
-  lemma foldl_union [DecidableEq B] (as: Array A) (f: A → Finset B) (S: Finset B) (b: B):  b ∈ (foldl (fun x y => x ∪ f y) S as) ↔ b ∈ S ∨ ∃ (a: A), a ∈ as ∧ b ∈ f a :=
-  by
-    cases as with
-    | mk data =>
-      simp
-      induction data generalizing S with
-      | nil =>
-        simp
-      | cons hd tl ih =>
-        unfold List.foldl
-        rw [ih]
-        simp
-        tauto
-
-  lemma get_mem (as: Array A) (i: Fin as.size): as[i] ∈ as :=
-  by
-    rw [mem_def]
-    apply getElem_mem_toList
-
 end Array

--- a/CertifyingDatalog/Datastructures/Finset.lean
+++ b/CertifyingDatalog/Datastructures/Finset.lean
@@ -4,10 +4,7 @@ namespace Finset
   -- added based on https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/finset.2Efilter
   noncomputable def filter_nc (p: A → Prop) (S: Finset A) := @Finset.filter A p (Classical.decPred p) S
 
-  lemma mem_filter_nc (a:A) (p: A → Prop) (S: Finset A) : a ∈ filter_nc p S ↔ p a ∧ a ∈ S :=
+  lemma mem_filter_nc {a:A} {p: A → Prop} {S: Finset A} : a ∈ filter_nc p S ↔ p a ∧ a ∈ S :=
   by
-    unfold filter_nc
-    simp [Finset.mem_filter]
-    rw [And.comm]
+    simp [filter_nc, Finset.mem_filter, And.comm]
 end Finset
-

--- a/CertifyingDatalog/Datastructures/Tree.lean
+++ b/CertifyingDatalog/Datastructures/Tree.lean
@@ -13,12 +13,10 @@ namespace Tree
   def elem  [DecidableEq A] (a: A) (t: Tree A): Bool  :=
     match t with
     | .node a' l => (a=a') ∨ List.any l.attach (fun ⟨x, _h⟩ => elem a x)
-  termination_by sizeOf t
 
   def elements (t: Tree A): List A :=
     match t with
     | .node a l => List.foldl (fun x ⟨y,_h⟩ => x ++ elements y) [a] l.attach
-  termination_by sizeOf t
 
   def root: Tree A → A
   | .node a _ => a
@@ -29,7 +27,6 @@ namespace Tree
   def height (t : Tree A): ℕ :=
     match t with
     | .node a l => 1 + (l.attach.map (fun ⟨x, _h⟩ => height x)).max?.getD 0
-  termination_by sizeOf t
 
   lemma height_def (a: A) (l: List (Tree A)): (Tree.node a l).height = 1 + (l.map height).max?.getD 0 :=
   by
@@ -41,13 +38,13 @@ namespace Tree
     cases t1 with
     | node a l =>
       unfold member at mem
-      simp at mem
+      simp only at mem
       rw [height_def]
 
       cases eq : (l.map height).max? with
       | none => rw [List.max?_eq_none_iff] at eq; simp at eq; rw [eq] at mem; contradiction
       | some max =>
-        simp
+        simp only [Option.getD_some]
         rw [Nat.lt_one_add_iff]
         rw [List.max?_eq_some_iff'] at eq
         apply eq.right
@@ -62,51 +59,50 @@ namespace Tree
       unfold elements
       rw [List.foldl_append_mem]
       unfold Tree.elem
-      simp
+      simp only [List.any_eq_true, List.mem_attach, true_and, Subtype.exists, exists_prop,
+        Bool.decide_or, Bool.or_eq_true, decide_eq_true_eq, List.mem_singleton]
       constructor
-      intro h
-      cases h with
-      | inl h =>
-        left
-        apply h
-      | inr h =>
-        rcases h with ⟨t', t_l, a_t⟩
-        specialize ih t'.height
-        have height_t': t'.height < n := by
-          rw [← h']
-          apply Tree.heightOfMemberIsSmaller
-          unfold Tree.member
-          simp
+      · intro h
+        cases h with
+        | inl h =>
+          left
+          apply h
+        | inr h =>
+          rcases h with ⟨t', t_l, a_t⟩
+          specialize ih t'.height
+          have height_t': t'.height < n := by
+            rw [← h']
+            apply Tree.heightOfMemberIsSmaller
+            unfold Tree.member
+            simp
+            apply t_l
+          specialize ih height_t' t'
+          right
+          use t'
+          constructor
           apply t_l
-        specialize ih height_t' t'
-        right
-        use t'
-        constructor
-        apply t_l
-        rw [← ih]
-        apply a_t
-        rfl
+          rw [← ih rfl]
+          apply a_t
 
-      intro h
-      cases h with
-      | inl h =>
-        left
-        apply h
-      | inr h =>
-        rcases h with ⟨t', t_l, a_t⟩
-        specialize ih t'.height
-        have height_t': t'.height < n := by
-          rw [← h']
-          apply Tree.heightOfMemberIsSmaller
-          unfold Tree.member
-          simp
-          apply t_l
-        specialize ih height_t' t'
-        right
-        use t'
-        constructor
-        apply t_l
-        rw [ih]
-        apply a_t
-        rfl
+      · intro h
+        cases h with
+        | inl h =>
+          left
+          apply h
+        | inr h =>
+          rcases h with ⟨t', t_l, a_t⟩
+          specialize ih t'.height
+          have height_t': t'.height < n := by
+            rw [← h']
+            apply Tree.heightOfMemberIsSmaller
+            unfold Tree.member
+            simp only
+            apply t_l
+          specialize ih height_t' t'
+          right
+          use t'
+          constructor
+          · apply t_l
+          · rw [ih rfl]
+            apply a_t
 end Tree

--- a/CertifyingDatalog/GraphValidation/Basic.lean
+++ b/CertifyingDatalog/GraphValidation/Basic.lean
@@ -11,11 +11,11 @@ namespace PreGraph
 
   def complete (pg: PreGraph A) := ∀ (a:A), pg.contains a →  ∀ (a':A), a' ∈ (pg.predecessors a) → pg.contains a'
 
-  theorem in_vertices_iff_contains (pg: PreGraph A) (a : A) : a ∈ pg.vertices ↔ pg.contains a := by
+  theorem in_vertices_iff_contains {pg: PreGraph A} {a : A} : a ∈ pg.vertices ↔ pg.contains a := by
     unfold vertices
     rw [Std.HashMap.mem_keys, Std.HashMap.mem_iff_contains]
 
-  theorem in_predecessors_iff_found (pg: PreGraph A) (a : A) : ∀ b, b ∈ pg.predecessors a ↔ b ∈ (pg.getD a []) := by
+  theorem in_predecessors_iff_found {pg: PreGraph A} {a : A} : ∀ b, b ∈ pg.predecessors a ↔ b ∈ (pg.getD a []) := by
     unfold predecessors; intros; rfl
 
   def from_vertices (vs : List A) : PreGraph A := Std.HashMap.ofList (vs.map (fun v => (v, [])))
@@ -29,98 +29,98 @@ namespace PreGraph
   def add_vertices (pg : PreGraph A) (vs : List A) : PreGraph A :=
     vs.foldl (fun (acc : PreGraph A) u => acc.add_vertex u) pg
 
-  theorem add_vertices_contains_iff_contains_or_in_list (pg : PreGraph A) (vs : List A) : ∀ v, (pg.add_vertices vs).contains v ↔ pg.contains v ∨ (¬ pg.contains v ∧ v ∈ vs) := by
+  theorem add_vertices_contains_iff_contains_or_in_list {pg : PreGraph A} {vs : List A} : ∀ v, (pg.add_vertices vs).contains v ↔ pg.contains v ∨ (¬ pg.contains v ∧ v ∈ vs) := by
     induction vs generalizing pg with
     | nil => simp [add_vertices]
     | cons u us ih =>
-      simp [add_vertices]
+      simp only [add_vertices, List.foldl_cons, Bool.not_eq_true, List.mem_cons]
       intro v
       unfold add_vertices at ih
       rw [ih]
       constructor
-      intro h
-      cases h with
-      | inl hl =>
-        unfold add_vertex at hl
-        split at hl
-        apply Or.inl
-        exact hl
-        rw [Std.HashMap.contains_insert] at hl
-        cases Decidable.em (pg.contains v) with
-        | inl v_in_pg => apply Or.inl; exact v_in_pg
-        | inr v_not_in_pg =>
-          simp at hl
-          cases hl with
-          | inl hl => apply Or.inr; constructor; simp at v_not_in_pg; exact v_not_in_pg; apply Or.inl; apply Eq.symm; exact hl
-          | inr _ => contradiction
-      | inr hr =>
-        unfold add_vertex at hr
-        split at hr
-        apply Or.inr
-        constructor
-        simp at hr
-        exact hr.left
-        apply Or.inr
-        exact hr.right
-        rw [Std.HashMap.contains_insert] at hr
-        cases Decidable.em (pg.contains v) with
-        | inl v_in_pg => apply Or.inl; exact v_in_pg
-        | inr v_not_in_pg => apply Or.inr; constructor; simp at v_not_in_pg; exact v_not_in_pg; apply Or.inr; exact hr.right
-      intro h
-      cases h with
-      | inl hl =>
-        apply Or.inl;
-        unfold add_vertex
-        split
-        exact hl
-        rw [Std.HashMap.contains_insert]
-        simp
-        apply Or.inr
-        exact hl
-      | inr hr =>
-        let ⟨hrl, hrr⟩ := hr
-        cases hrr with
-        | inl v_is_u =>
-          apply Or.inl
+      · intro h
+        cases h with
+        | inl hl =>
+          unfold add_vertex at hl
+          split at hl
+          · apply Or.inl
+            exact hl
+          · rw [Std.HashMap.contains_insert] at hl
+            cases Decidable.em (pg.contains v) with
+            | inl v_in_pg => apply Or.inl; exact v_in_pg
+            | inr v_not_in_pg =>
+              simp only [Bool.or_eq_true, beq_iff_eq] at hl
+              cases hl with
+              | inl hl => apply Or.inr; constructor; simp only [Bool.not_eq_true] at v_not_in_pg; exact v_not_in_pg; apply Or.inl; apply Eq.symm; exact hl
+              | inr _ => contradiction
+        | inr hr =>
+          unfold add_vertex at hr
+          split at hr
+          · apply Or.inr
+            constructor
+            · simp only [Bool.not_eq_true] at hr
+              exact hr.left
+            · apply Or.inr
+              exact hr.right
+          · rw [Std.HashMap.contains_insert] at hr
+            cases Decidable.em (pg.contains v) with
+            | inl v_in_pg => apply Or.inl; exact v_in_pg
+            | inr v_not_in_pg => apply Or.inr; constructor; simp at v_not_in_pg; exact v_not_in_pg; apply Or.inr; exact hr.right
+      · intro h
+        cases h with
+        | inl hl =>
+          apply Or.inl;
           unfold add_vertex
           split
-          case isTrue u_in_pg =>
-            apply False.elim; rw [v_is_u] at hrl
-            have : ¬ pg.contains u := by simp [hrl]
-            contradiction
-          rw [Std.HashMap.contains_insert]
-          simp
-          apply Or.inl
-          rw [v_is_u]
-        | inr v_in_us =>
-          cases Decidable.em ((pg.add_vertex u).contains v)
-          apply Or.inl
-          assumption
-          apply Or.inr
-          constructor
-          assumption
-          exact v_in_us
+          · exact hl
+          · rw [Std.HashMap.contains_insert]
+            simp only [Bool.or_eq_true, beq_iff_eq]
+            apply Or.inr
+            exact hl
+        | inr hr =>
+          let ⟨hrl, hrr⟩ := hr
+          cases hrr with
+          | inl v_is_u =>
+            apply Or.inl
+            unfold add_vertex
+            split
+            · case isTrue u_in_pg =>
+              apply False.elim; rw [v_is_u] at hrl
+              have : ¬ pg.contains u := by simp [hrl]
+              contradiction
+            · rw [Std.HashMap.contains_insert]
+              simp
+              apply Or.inl
+              rw [v_is_u]
+          | inr v_in_us =>
+            cases Decidable.em ((pg.add_vertex u).contains v)
+            · apply Or.inl
+              assumption
+            · apply Or.inr
+              constructor
+              · assumption
+              · exact v_in_us
 
   theorem add_vertices_getD_semantics (pg : PreGraph A) (vs : List A) (a : A): (pg.add_vertices vs).getD a [] = pg.getD a [] := by
     induction vs generalizing pg with
     | nil => simp [add_vertices]
     | cons u us ih =>
-      simp [add_vertices]
+      simp only [add_vertices, List.foldl_cons]
       have ih_plugged_in := ih (pg.add_vertex u)
       unfold add_vertices at ih_plugged_in
       rw [ih_plugged_in]
       unfold add_vertex
       split
       . rfl
-      case isFalse h =>
-        rw [Std.HashMap.getD_insert]
-        simp
-        intro eq
-        apply Eq.symm
-        rw [Std.HashMap.getD_eq_fallback_of_contains_eq_false]
-        rw [← eq]
-        simp at h
-        exact h
+      · case isFalse h =>
+          rw [Std.HashMap.getD_insert]
+          simp only [beq_iff_eq, ite_eq_right_iff, List.nil_eq]
+          intro eq
+          apply Eq.symm
+          rw [Std.HashMap.getD_eq_fallback_of_contains_eq_false]
+          rw [← eq]
+          simp only [Bool.not_eq_true] at h
+          exact h
 
   def add_vertex_with_predecessors (pg : PreGraph A) (v : A) (vs : List A) : PreGraph A :=
     let pg_with_added_predecessors := if pg.contains v then pg.insert v ((pg.predecessors v) ++ vs) else pg.insert v vs
@@ -161,206 +161,205 @@ namespace PreGraph
 
   theorem add_vertex_with_predecessors_contains_iff_contains_or_in_new_vertices (pg : PreGraph A) (v : A) (vs : List A) : ∀ a, (pg.add_vertex_with_predecessors v vs).contains a ↔ (pg.contains a ∧ a = v) ∨ (pg.contains a ∧ a ≠ v) ∨ ((¬ pg.contains a) ∧ a = v) ∨ ((¬ pg.contains a) ∧ a ≠ v ∧ a ∈ vs) := by
     unfold add_vertex_with_predecessors
-    simp
+    simp only [ne_eq, Bool.not_eq_true]
     intro a
     rw [add_vertices_contains_iff_contains_or_in_list]
     constructor
-    intro h
-    cases h with
-    | inl hl =>
-      split at hl
-      case isTrue hl' =>
-        rw [Std.HashMap.contains_insert] at hl
-        simp at hl
-        cases hl with
+    · intro h
+      cases h with
+      | inl hl =>
+        split at hl
+        case isTrue hl' =>
+          rw [Std.HashMap.contains_insert] at hl
+          simp only [Bool.or_eq_true, beq_iff_eq] at hl
+          cases hl with
+          | inl hll =>
+            apply Or.inl
+            constructor
+            · rw [← hll]
+              apply hl'
+            · rw [hll]
+          | inr hlr =>
+            cases Decidable.em (a = v) with
+            | inl a_eq_v => apply Or.inl; constructor; exact hlr; exact a_eq_v
+            | inr a_neq_v => apply Or.inr; apply Or.inl; constructor; exact hlr; exact a_neq_v
+        case isFalse hr' =>
+          rw [Std.HashMap.contains_insert] at hl
+          simp only [Bool.or_eq_true, beq_iff_eq] at hl
+          cases hl with
+          | inl hll =>
+            apply Or.inr
+            apply Or.inr
+            apply Or.inl
+            constructor
+            · rw [← hll]
+              simp only [Bool.not_eq_true] at hr'
+              apply hr'
+            · rw [hll]
+          | inr hlr =>
+            cases Decidable.em (a = v) with
+            | inl a_eq_v => apply Or.inl; constructor; exact hlr; exact a_eq_v
+            | inr a_neq_v => apply Or.inr; apply Or.inl; constructor; exact hlr; exact a_neq_v
+      | inr hr =>
+        let ⟨hrl, hrr⟩ := hr
+        split at hrl
+        case isTrue hl' =>
+          rw [Std.HashMap.contains_insert] at hrl
+          simp only [Bool.or_eq_true, beq_iff_eq, not_or, Bool.not_eq_true] at hrl
+          cases Decidable.em (a = v) with
+          | inl a_eq_v =>
+            rw [a_eq_v] at hrl
+            have contra := hrl.left
+            contradiction
+          | inr a_neq_v =>
+            cases Decidable.em (pg.contains a) with
+            | inl pg_contains =>
+              rw [pg_contains] at hrl
+              have contra := hrl.right
+              contradiction
+            | inr pg_not_contains =>
+              apply Or.inr
+              apply Or.inr
+              apply Or.inr
+              constructor
+              simp only [Bool.not_eq_true] at pg_not_contains
+              apply pg_not_contains
+              constructor
+              · apply a_neq_v
+              · apply hrr
+        case isFalse hr' =>
+          rw [Std.HashMap.contains_insert] at hrl
+          simp only [Bool.or_eq_true, beq_iff_eq, not_or, Bool.not_eq_true] at hrl
+          cases Decidable.em (a = v) with
+          | inl a_eq_v =>
+            rw [a_eq_v] at hrl
+            have contra := hrl.left
+            contradiction
+          | inr a_neq_v =>
+            cases Decidable.em (pg.contains a) with
+            | inl pg_contains =>
+              rw [pg_contains] at hrl
+              have contra := hrl.right
+              contradiction
+            | inr pg_not_contains =>
+              apply Or.inr
+              apply Or.inr
+              apply Or.inr
+              constructor
+              · simp only [Bool.not_eq_true] at pg_not_contains
+                apply pg_not_contains
+              · constructor
+                · apply a_neq_v
+                · apply hrr
+    · intro h
+      cases h with
+      | inl hll =>
+        apply Or.inl
+        split
+        · rw [Std.HashMap.contains_insert]
+          simp only [Bool.or_eq_true, beq_iff_eq]
+          apply Or.inl
+          rw [hll.right]
+        · rw [Std.HashMap.contains_insert]
+          simp only [Bool.or_eq_true, beq_iff_eq]
+          apply Or.inl
+          rw [hll.right]
+      | inr hlr => cases hlr with
         | inl hll =>
           apply Or.inl
-          constructor
-          rw [← hll]
-          apply hl'
-          rw [hll]
-        | inr hlr =>
-          cases Decidable.em (a = v) with
-          | inl a_eq_v => apply Or.inl; constructor; exact hlr; exact a_eq_v
-          | inr a_neq_v => apply Or.inr; apply Or.inl; constructor; exact hlr; exact a_neq_v
-      case isFalse hr' =>
-        rw [Std.HashMap.contains_insert] at hl
-        simp at hl
-        cases hl with
-        | inl hll =>
-          apply Or.inr
-          apply Or.inr
-          apply Or.inl
-          constructor
-          rw [← hll]
-          simp at hr'
-          apply hr'
-          rw [hll]
-        | inr hlr =>
-          cases Decidable.em (a = v) with
-          | inl a_eq_v => apply Or.inl; constructor; exact hlr; exact a_eq_v
-          | inr a_neq_v => apply Or.inr; apply Or.inl; constructor; exact hlr; exact a_neq_v
-    | inr hr =>
-      let ⟨hrl, hrr⟩ := hr
-      split at hrl
-      case isTrue hl' =>
-        rw [Std.HashMap.contains_insert] at hrl
-        simp at hrl
-        cases Decidable.em (a = v) with
-        | inl a_eq_v =>
-          rw [a_eq_v] at hrl
-          have contra := hrl.left
-          contradiction
-        | inr a_neq_v =>
-          cases Decidable.em (pg.contains a) with
-          | inl pg_contains =>
-            rw [pg_contains] at hrl
-            have contra := hrl.right
-            contradiction
-          | inr pg_not_contains =>
+          split
+          · rw [Std.HashMap.contains_insert]
+            simp only [Bool.or_eq_true, beq_iff_eq]
             apply Or.inr
+            rw [hll.left]
+          · rw [Std.HashMap.contains_insert]
+            simp only [Bool.or_eq_true, beq_iff_eq]
             apply Or.inr
+            rw [hll.left]
+        | inr hlr => cases hlr with
+          | inl hll =>
+            apply Or.inl
+            split
+            · rw [Std.HashMap.contains_insert]
+              simp only [Bool.or_eq_true, beq_iff_eq]
+              apply Or.inr
+              rw [hll.right]
+              assumption
+            · rw [Std.HashMap.contains_insert]
+              simp only [Bool.or_eq_true, beq_iff_eq]
+              apply Or.inl
+              rw [hll.right]
+          | inr hlr =>
             apply Or.inr
-            constructor
-            simp at pg_not_contains
-            apply pg_not_contains
-            constructor
-            apply a_neq_v
-            apply hrr
-      case isFalse hr' =>
-        rw [Std.HashMap.contains_insert] at hrl
-        simp at hrl
-        cases Decidable.em (a = v) with
-        | inl a_eq_v =>
-          rw [a_eq_v] at hrl
-          have contra := hrl.left
-          contradiction
-        | inr a_neq_v =>
-          cases Decidable.em (pg.contains a) with
-          | inl pg_contains =>
-            rw [pg_contains] at hrl
-            have contra := hrl.right
-            contradiction
-          | inr pg_not_contains =>
-            apply Or.inr
-            apply Or.inr
-            apply Or.inr
-            constructor
-            simp at pg_not_contains
-            apply pg_not_contains
-            constructor
-            apply a_neq_v
-            apply hrr
-
-    intro h
-    cases h with
-    | inl hll =>
-      apply Or.inl
-      split
-      rw [Std.HashMap.contains_insert]
-      simp
-      apply Or.inl
-      rw [hll.right]
-      rw [Std.HashMap.contains_insert]
-      simp
-      apply Or.inl
-      rw [hll.right]
-    | inr hlr => cases hlr with
-    | inl hll =>
-      apply Or.inl
-      split
-      rw [Std.HashMap.contains_insert]
-      simp
-      apply Or.inr
-      rw [hll.left]
-      rw [Std.HashMap.contains_insert]
-      simp
-      apply Or.inr
-      rw [hll.left]
-    | inr hlr => cases hlr with
-    | inl hll =>
-      apply Or.inl
-      split
-      rw [Std.HashMap.contains_insert]
-      simp
-      apply Or.inr
-      rw [hll.right]
-      assumption
-      rw [Std.HashMap.contains_insert]
-      simp
-      apply Or.inl
-      rw [hll.right]
-    | inr hlr =>
-      apply Or.inr
-      split
-      rw [Std.HashMap.contains_insert]
-      simp
-      constructor
-      constructor
-      intro contra
-      apply hlr.right.left
-      rw [contra]
-      apply hlr.left
-      apply hlr.right.right
-      constructor
-      intro contra
-      rw [Std.HashMap.contains_insert] at contra
-      simp at contra
-      cases contra with
-      | inl contra => apply hlr.right.left; rw [contra]
-      | inr contra => have contra' := hlr.left; rw [contra'] at contra; contradiction
-      apply hlr.right.right
+            split
+            · rw [Std.HashMap.contains_insert]
+              simp
+              constructor
+              · constructor
+                · intro contra
+                  apply hlr.right.left
+                  rw [contra]
+                · apply hlr.left
+              · apply hlr.right.right
+            · constructor
+              · intro contra
+                rw [Std.HashMap.contains_insert] at contra
+                simp only [Bool.or_eq_true, beq_iff_eq] at contra
+                cases contra with
+                | inl contra => apply hlr.right.left; rw [contra]
+                | inr contra => have contra' := hlr.left; rw [contra'] at contra; contradiction
+              · apply hlr.right.right
 
   theorem add_vertex_with_predecessors_getD_semantics_1 (pg : PreGraph A) (v a : A) (vs : List A) (h : pg.contains a ∧ a = v) : (pg.add_vertex_with_predecessors v vs).getD a [] = (pg.predecessors v) ++ vs := by
     unfold add_vertex_with_predecessors
-    simp
+    simp only
     rw [add_vertices_getD_semantics]
     rw [← h.right]
     simp [h.left]
 
   theorem add_vertex_with_predecessors_getD_semantics_2 (pg : PreGraph A) (v a : A) (vs : List A) (h : pg.contains a ∧ a ≠ v) : (pg.add_vertex_with_predecessors v vs).getD a [] = (pg.predecessors a) := by
     unfold add_vertex_with_predecessors
-    simp
+    simp only
     rw [add_vertices_getD_semantics]
     split
-    rw [Std.HashMap.getD_insert]
-    simp
-    split
-    case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
-    unfold predecessors
-    rfl
-    rw [Std.HashMap.getD_insert]
-    simp
-    split
-    case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
-    unfold predecessors
-    rfl
+    · rw [Std.HashMap.getD_insert]
+      simp only [beq_iff_eq]
+      split
+      · case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
+      · unfold predecessors
+        rfl
+    · rw [Std.HashMap.getD_insert]
+      simp only [beq_iff_eq]
+      split
+      · case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
+      · unfold predecessors
+        rfl
 
   theorem add_vertex_with_predecessors_getD_semantics_3 (pg : PreGraph A) (v a : A) (vs : List A) (h : (¬ pg.contains a) ∧ a = v) : (pg.add_vertex_with_predecessors v vs).getD a [] = vs := by
     unfold add_vertex_with_predecessors
-    simp
+    simp only
     rw [add_vertices_getD_semantics]
     rw [← h.right]
     simp [h.left]
 
   theorem add_vertex_with_predecessors_getD_semantics_4 (pg : PreGraph A) (v a : A) (vs : List A) (h : (¬ pg.contains a) ∧ a ≠ v) : (pg.add_vertex_with_predecessors v vs).getD a [] = [] := by
     unfold add_vertex_with_predecessors
-    simp
-    simp at h
+    simp only
+    simp only [Bool.not_eq_true, ne_eq] at h
     rw [add_vertices_getD_semantics]
     split
-    rw [Std.HashMap.getD_insert]
-    simp
-    split
-    case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
-    rw [Std.HashMap.getD_eq_fallback_of_contains_eq_false]
-    apply h.left
-    rw [Std.HashMap.getD_insert]
-    simp
-    split
-    case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
-    rw [Std.HashMap.getD_eq_fallback_of_contains_eq_false]
-    apply h.left
+    · rw [Std.HashMap.getD_insert]
+      simp
+      split
+      · case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
+      · rw [Std.HashMap.getD_eq_fallback_of_contains_eq_false]
+        apply h.left
+    · rw [Std.HashMap.getD_insert]
+      simp only [beq_iff_eq]
+      split
+      · case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
+      · rw [Std.HashMap.getD_eq_fallback_of_contains_eq_false]
+        apply h.left
 
   theorem add_vertex_with_predecessors_still_complete (pg : PreGraph A) (v : A) (vs : List A) (pg_is_complete : pg.complete) : (pg.add_vertex_with_predecessors v vs).complete := by
     unfold complete

--- a/CertifyingDatalog/GraphValidation/Walks.lean
+++ b/CertifyingDatalog/GraphValidation/Walks.lean
@@ -10,9 +10,10 @@ namespace Walk
   def singleton (G : Graph A) (a:A) (mem: a ∈ G.vertices) : Walk G := ⟨[a], by
     unfold List.isWalk
     constructor
-    · simp
+    · simp only [List.mem_singleton, forall_eq]
       apply mem
-    · simp
+    · simp only [gt_iff_lt, List.length_singleton, Nat.lt_one_iff, List.getElem_singleton,
+      Nat.pred_eq_sub_one]
       intro i i_gt_0 i_0
       simp [i_0] at i_gt_0
   ⟩
@@ -34,8 +35,11 @@ namespace Walk
     match eq : w.val.indexOf b with
     | .zero => w.val.get ⟨w.val.length - 2, by
       rw [Nat.sub_lt_iff_lt_add']
-      simp
-      unfold isCycle at cyc; apply Decidable.by_contra; intro contra; simp at contra; simp [contra] at cyc
+      simp only [Nat.lt_add_right_iff_pos, Nat.zero_lt_succ]
+      unfold isCycle at cyc; apply Decidable.by_contra
+      intro contra
+      simp only [not_le] at contra
+      simp only [contra, ↓reduceDIte] at cyc
     ⟩
       -- (by intro contra; simp [contra] at b_mem)
     | .succ n => w.val.get ⟨n, by apply Nat.lt_of_succ_le; rw [← eq]; apply List.indexOf_le_length⟩
@@ -50,24 +54,21 @@ namespace Walk
     case h_1 eq =>
       unfold isCycle at cyc
       have : ¬ w.val.length < 2 := by apply Decidable.by_contra; intro contra; simp at contra; simp [contra] at cyc
-      simp [this] at cyc
-      simp at eq
-      simp [← eq] at cyc
+      simp only [this, ↓reduceDIte, List.get_eq_getElem, Nat.pred_eq_sub_one] at cyc
+      simp only [Nat.zero_eq] at eq
+      simp only [← eq, List.getElem_indexOf] at cyc
       rw [cyc]
       have prop := w.prop.right
       apply prop
-      simp
-      simp at this
-      apply Nat.lt_sub_of_add_lt
-      apply Nat.lt_of_succ_le
-      simp
-      exact this
+      simp only [gt_iff_lt]
+      simp only [not_lt] at this
+      omega
     case h_2 n eq =>
       have : b = w.val.get ⟨n.succ, by rw [← eq, List.indexOf_lt_length]; exact b_mem⟩ := by simp at eq; simp [← eq]
-      simp [this]
+      simp only [this, Nat.succ_eq_add_one, List.get_eq_getElem]
       have prop := w.prop.right
       apply prop (n + 1)
-      simp
+      simp only [gt_iff_lt, Nat.zero_lt_succ]
 
   def predecessors {G: Graph A} (walk: Walk G) : List A := match walk.val.head? with
     | .none => []
@@ -84,7 +85,7 @@ namespace Walk
     rcases walk_prop with ⟨subs,connected⟩
     constructor
     · intro b
-      simp
+      simp only [Nat.pred_eq_sub_one, List.mem_cons]
       intro h
       cases h with
       | inl h =>
@@ -93,12 +94,11 @@ namespace Walk
         cases eq : walk.val.head? with
         | none => simp [eq] at is_pred
         | some head =>
-          apply Graph.mem_of_is_pred
-          simp [eq] at is_pred
-          apply is_pred
+          simp only [eq] at is_pred
+          apply Graph.mem_of_is_pred _ _ _ is_pred
       | inr h =>
         apply subs
-        simp
+        simp only [Nat.pred_eq_sub_one]
         apply h
     · intro i i_zero i_len
       cases i with
@@ -108,7 +108,7 @@ namespace Walk
         rw [List.getElem_cons_succ]
         cases j with
         | zero =>
-          simp
+          simp only [Nat.pred_eq_sub_one, Nat.zero_add, Nat.sub_self, List.getElem_cons_zero]
           unfold predecessors at is_pred
           cases eq : walk.val.head? with
           | none => simp [eq] at is_pred
@@ -120,10 +120,11 @@ namespace Walk
             rw [eq]
             apply is_pred
         | succ k =>
-          simp
+          simp only [Nat.pred_eq_sub_one, Nat.add_one_sub_one, List.getElem_cons_succ]
           specialize connected (Nat.succ k)
-          simp at connected
-          simp at i_len
+          simp only [Nat.succ_eq_add_one, gt_iff_lt, Nat.zero_lt_succ, Nat.pred_eq_sub_one,
+            Nat.add_one_sub_one, forall_const] at connected
+          simp only [Nat.pred_eq_sub_one, List.length_cons, Nat.add_lt_add_iff_right] at i_len
           specialize connected i_len
           apply connected
   ⟩
@@ -132,7 +133,7 @@ namespace Walk
     unfold List.isWalk
     constructor
     · intro a a_elem
-      simp at a_elem
+      simp only [Nat.pred_eq_sub_one, List.mem_append, List.mem_singleton] at a_elem
       cases a_elem with
       | inl h => apply walk.prop.left; exact h
       | inr h =>
@@ -140,7 +141,7 @@ namespace Walk
         cases eq : walk.val.getLast? with
         | none => simp [eq] at is_succ
         | some last =>
-          simp [eq] at is_succ
+          simp only [eq, List.mem_filter, decide_eq_true_eq] at is_succ
           rw [h]
           apply is_succ.left
     · intro i i_zero i_len
@@ -150,12 +151,13 @@ namespace Walk
         simp
         rw [List.getElem_append]
         rw [List.getElem_append]
-        simp at i_lt
-        simp [i_lt]
+        simp only [Nat.pred_eq_sub_one, List.length_append, List.length_singleton,
+          Nat.add_one_sub_one] at i_lt
+        simp only [i_lt, ↓reduceDIte, List.getElem_singleton]
         have i_pred_lt: i -1 < walk.1.length := by
           rw [← Nat.pred_eq_sub_one]
           apply Nat.lt_trans (Nat.pred_lt_of_lt i_zero) i_lt
-        simp [i_pred_lt]
+        simp only [i_pred_lt, ↓reduceDIte]
         apply prop
         apply i_zero
       | inr i_eq =>
@@ -163,20 +165,22 @@ namespace Walk
         cases eq : walk.val.getLast? with
         | none => simp [eq] at is_succ
         | some last =>
-          simp at i_eq
-          simp [eq] at is_succ
+          simp only [Nat.pred_eq_sub_one, List.length_append, List.length_singleton,
+            Nat.add_one_sub_one] at i_eq
+          simp only [eq, List.mem_filter, decide_eq_true_eq] at is_succ
           have ⟨_, last_pred_of_succ⟩ := is_succ
-          simp
+          simp only [Nat.pred_eq_sub_one]
           rw [List.getElem_append]
           rw [List.getElem_append]
-          simp [i_eq]
+          simp only [i_eq, lt_self_iff_false, ↓reduceDIte, Nat.sub_self, List.getElem_cons_zero,
+            Nat.sub_le, Nat.sub_eq_zero_of_le]
           have h: walk.1.length - 1 < walk.1.length := by
             rw [← i_eq,←  Nat.pred_eq_sub_one]
             apply Nat.pred_lt (Ne.symm (Nat.ne_of_lt i_zero))
-          simp [h]
+          simp only [h, ↓reduceDIte]
           rw [List.getLast?_eq_getElem?] at eq
           rw [LawfulGetElem.getElem?_def] at eq
-          simp [h] at eq
+          simp only [h, ↓reduceDIte, Option.some.injEq] at eq
           rw [eq]
           apply last_pred_of_succ
   ⟩
@@ -198,38 +202,47 @@ namespace Walk
       exact a_mem
     · intro i i_gt_0 i_lt_len
       specialize conn (Nat.succ i)
-      simp at conn
-      simp at i_lt_len
+      simp only [Nat.succ_eq_add_one, gt_iff_lt, Nat.zero_lt_succ, Nat.pred_eq_sub_one,
+        Nat.add_one_sub_one, forall_const] at conn
+      simp only [Nat.pred_eq_sub_one, List.length_tail] at i_lt_len
       have : 0 < walk.val.length := by
         apply lt_trans
         apply i_gt_0
         apply Nat.lt_of_lt_pred
         apply i_lt_len
       rw [walk.val.tail_getElem this i.pred]
-      rw [walk.val.tail_getElem this i]
-      simp [Nat.sub_one_add_one_eq_of_pos i_gt_0]
-      apply conn
-      apply i_lt_len
-      apply lt_trans
-      apply Nat.pred_lt_of_lt
-      apply i_gt_0
-      apply i_lt_len
+      · rw [walk.val.tail_getElem this i]
+        · simp only [Nat.succ_eq_add_one, Nat.pred_eq_sub_one,
+          Nat.sub_one_add_one_eq_of_pos i_gt_0]
+          apply conn
+        · apply i_lt_len
+      · apply lt_trans
+        · apply Nat.pred_lt_of_lt
+          apply i_gt_0
+        · apply i_lt_len
   ⟩
 
   lemma head_in_tail_predecessors {G : Graph A} (w : Walk G) (neq : w.val.tail ≠ []) : w.val.head (by intro contra; rw [contra] at neq; simp at neq) ∈ w.tail.predecessors := by
     unfold predecessors
     rw [@List.head?_eq_head _ w.tail.val neq]
-    simp
+    simp only
     have : 0 < w.val.length := by apply Decidable.by_contra; intro contra; simp at contra; rw [contra] at neq; simp at neq
-    have this2 : 0 < w.tail.val.length := by apply Decidable.by_contra; intro contra; simp at contra; unfold tail at contra; simp at contra; rw [contra] at neq; simp at neq
+    have this2 : 0 < w.tail.val.length := by
+      apply Decidable.by_contra
+      intro contra
+      simp only [not_lt, Nat.le_zero_eq, List.length_eq_zero] at contra
+      unfold tail at contra
+      simp only at contra
+      rw [contra] at neq
+      simp at neq
     rw [← List.getElem_zero this]
     rw [← List.getElem_zero this2]
     unfold Walk.tail
     rw [List.tail_getElem w.val this 0]
-    apply w.prop.right 1 (by simp)
-    rw [← List.length_tail]
-    unfold tail at this2
-    exact this2
+    · apply w.prop.right 1 (by simp)
+    · rw [← List.length_tail]
+      unfold tail at this2
+      exact this2
 
   def take {G : Graph A} (walk : Walk G) (n : Nat) : Walk G := ⟨walk.val.take n, by
     have prop := walk.prop
@@ -238,8 +251,7 @@ namespace Walk
     constructor
     · intro a a_in_take
       apply subs
-      apply List.mem_of_mem_take
-      exact a_in_take
+      apply List.mem_of_mem_take a_in_take
     · intro i i_gt_0 i_lt_len
       rw [List.getElem_take]
       rw [List.getElem_take]
@@ -253,7 +265,7 @@ namespace Walk
     unfold takeUntil
     intro contra
     unfold take at contra
-    simp at contra
+    simp only [List.take_eq_nil_iff, Nat.add_one_ne_zero, false_or] at contra
     contradiction
 
   lemma takeUntil_head_same {G : Graph A} (w : Walk G) (ne : w.val ≠ []) (a : A) : (w.takeUntil a).val.head (by apply w.takeUnil_ne_of_ne ne) = w.val.head ne := by
@@ -266,7 +278,7 @@ namespace Walk
     unfold predecessors
     rw [List.head?_eq_head ne]
     rw [List.head?_eq_head (by apply takeUnil_ne_of_ne _ ne)]
-    simp
+    simp only
     rw [takeUntil_head_same]
 
   lemma takeUntil_getLast_is_target {G : Graph A} (w : Walk G) (a : A) (mem : a ∈ w.val) : (w.takeUntil a).val.getLast (by apply takeUnil_ne_of_ne; intro contra; rw [contra] at mem; simp at mem) = a := by
@@ -287,7 +299,7 @@ namespace Walk
     unfold List.isWalk
     constructor
     · intro a a_in_append
-      simp at a_in_append
+      simp only [Nat.pred_eq_sub_one, List.mem_append] at a_in_append
       cases a_in_append
       · apply subs1; assumption
       · apply subs2; rename_i h'; apply List.mem_of_mem_tail h'
@@ -298,7 +310,7 @@ namespace Walk
       · split
         · apply conn1 _ i_gt_0
         · rename_i h h'
-          simp at h'
+          simp only [Nat.pred_eq_sub_one, not_lt] at h'
           have w1_lt_w1: w1.1.length < w1.1.length := by
             have i_pred_lt_i: i.pred < i := by
               apply Nat.pred_lt (Nat.ne_of_gt i_gt_0)
@@ -308,7 +320,7 @@ namespace Walk
           simp at w1_lt_w1
       · split
         · rename_i h h'
-          simp at h
+          simp only [Nat.pred_eq_sub_one, not_lt] at h
           apply Nat.eq_or_lt_of_le at h
           cases h with
           | inl h =>
@@ -316,29 +328,29 @@ namespace Walk
             rw [List.getLast_eq_getElem] at w1_w2_conn
             simp only [Nat.pred_eq_sub_one, ← h]
             rw [w1_w2_conn]
-            simp
+            simp only [Nat.sub_self, List.getElem_tail, Nat.zero_add]
             rw [List.head_eq_getElem]
             specialize conn2 1
             apply conn2
             simp
           | inr h =>
             rw [Nat.lt_iff_le_pred i_gt_0] at h
-            simp at h'
+            simp only [Nat.pred_eq_sub_one] at h'
             have := Nat.lt_of_lt_of_le h' h
             simp at this
         · simp only [Nat.pred_sub]
           rename_i h h'
-          simp at h
+          simp only [Nat.pred_eq_sub_one, not_lt] at h
           apply Nat.eq_or_lt_of_le at h
           cases h with
           | inl h =>
             rw [h] at h'
-            simp at h'
+            simp only [Nat.pred_eq_sub_one, not_lt] at h'
             rw [← Nat.pred_eq_sub_one] at h'
             rw [Nat.le_pred_iff_lt i_gt_0] at h'
             simp at h'
           | inr h =>
-            simp[List.getElem_tail]
+            simp only [Nat.pred_eq_sub_one, List.getElem_tail]
             have idx: i - w1.1.length - 1 + 1 = (i - w1.1.length +1).pred := by
               refine Nat.sub_add_cancel ?_
               exact Nat.le_sub_of_add_le' h
@@ -363,7 +375,7 @@ namespace Walk
         intro contra; rw [contra] at h; simp at h
       have : ¬ (w.tail.takeUntil (w.val.head neq)).val.length + 1 < 2 := by
         apply Nat.not_lt_of_le
-        simp
+        simp only [Nat.reduceLeDiff]
         apply Nat.succ_le_of_lt
         apply this
       contradiction
@@ -374,8 +386,10 @@ namespace Walk
         apply takeUnil_ne_of_ne
         intro contra; rw [contra] at h; simp at h
       have get_cons := @List.getElem_cons_succ _ (w.val.head neq) (w.tail.takeUntil (w.val.head neq)).val ((w.tail.takeUntil (w.val.head neq)).val.length - 1) (by rw [this]; simp)
-      simp [this] at get_cons
-      simp
+      simp only [this] at get_cons
+      simp only [eq_mp_eq_cast, id_eq, eq_mpr_eq_cast, List.length_cons, Fin.zero_eta,
+        List.get_eq_getElem, Fin.val_zero, List.getElem_cons_zero, Nat.pred_eq_sub_one,
+        Nat.add_one_sub_one]
       rw [get_cons]
       have applied_takeUntil_getLast_is_target := w.tail.takeUntil_getLast_is_target (w.val.head neq) h
       rw [List.getLast_eq_getElem] at applied_takeUntil_getLast_is_target
@@ -397,7 +411,7 @@ namespace Graph
     exists ((Walk.singleton G b (by apply mem_of_has_pred; apply a_pred)).prependPredecessor a (by
       unfold Walk.singleton
       unfold Walk.predecessors
-      simp
+      simp only [List.head?_cons]
       apply a_pred
     ))
     exists (by simp [Walk.singleton, Walk.prependPredecessor])
@@ -425,17 +439,17 @@ namespace Graph
           cases list with
           | nil => simp at w_b_c_neq
           | cons head tail =>
-            simp at eq
-            simp [eq]
-            simp [eq] at w_last_c
+            simp only [List.tail_cons] at eq
+            simp only [eq]
+            simp only [eq, List.getLast_singleton] at w_last_c
             simp [w_last_c]
         unfold Walk.concat
-        simp [this]
+        simp only [this]
         unfold Walk.singleton
-        simp
+        simp only [List.tail_cons, List.append_nil]
         rw [w_last_b]
         rw [← w_head_b]
-        simp [this]
+        simp only [this]
         unfold Walk.singleton
         simp
       | inr neq =>
@@ -451,7 +465,7 @@ namespace Graph
     exists w.appendSuccessor c (by
       unfold Walk.successors
       rw [List.getLast?_eq_getLast]
-      simp
+      simp only [List.mem_filter, decide_eq_true_eq]
       constructor
       · apply mem_of_has_pred
         apply a_pred
@@ -476,8 +490,8 @@ namespace Graph
         cases ds with
         | nil =>
           apply Or.inl
-          simp [eq] at head
-          simp [eq] at last
+          simp only [eq, List.head_cons] at head
+          simp only [eq, List.getLast_singleton] at last
           constructor
           · apply w.prop.left
             rw [eq]
@@ -518,10 +532,10 @@ namespace Graph
     unfold verticesThatReach
     rw [Finset.mem_filter_nc]
     constructor
-    apply canReach_refl
-    apply mem
-    simp
-    apply mem
+    · apply canReach_refl
+      apply mem
+    · simp only [List.mem_toFinset]
+      apply mem
 
   lemma verticesThatReachPredSubsetReachSelf (G : Graph A) (c : A) : ∀ b, b ∈ G.predecessors c -> G.verticesThatReach b ⊆ G.verticesThatReach c := by
     intro b b_pred
@@ -545,7 +559,7 @@ namespace Graph
       apply acyclic (w.appendSuccessor b (by
         unfold Walk.successors
         rw [List.getLast?_eq_getLast]
-        simp
+        simp only [List.mem_filter, decide_eq_true_eq]
         constructor
         · apply mem_of_has_pred
           apply a_pred
@@ -560,11 +574,12 @@ namespace Graph
         have contra : ¬ List.length (head :: tail) + 1 < 2 := by simp
         exact contra h
       case isFalse h =>
-        simp
+        simp only [id_eq, eq_mpr_eq_cast, List.get_eq_getElem, Nat.pred_eq_sub_one]
         unfold Walk.appendSuccessor
         rw [List.getElem_append_left]
         · rw [List.getElem_append_right]
-          · simp
+          · simp only [List.length_append, List.length_singleton, Nat.add_one_sub_one,
+            Nat.sub_self, List.getElem_cons_zero]
             rw [← get_b]
             apply List.get_mk_zero
           · simp [eq]
@@ -587,8 +602,7 @@ namespace Graph
       apply G.selfNotInVerticesThatReachPred acyclic c b b_pred
       apply contra
       apply verticesThatReachContainSelf
-      apply mem_of_has_pred
-      apply b_pred
+      apply mem_of_has_pred _ _ _ b_pred
 
   def reachableFromCycle (G: Graph A) (b : A) := ∃ (w : Walk G), w.isCycle ∧ ∃ (a: A), a ∈ w.val ∧ G.canReach a b
 
@@ -632,17 +646,17 @@ namespace Graph
         have : 0 < w.val.length - 1 := by
           apply Decidable.by_contra
           intro contra
-          simp at contra
+          simp only [not_lt, Nat.le_zero_eq] at contra
           cases eq : w.val with
           | nil => simp [eq] at w_neq
           | cons c cs =>
             have : cs = [] := by
               rw [eq] at contra
-              simp at contra
+              simp only [List.length_cons, Nat.add_one_sub_one, List.length_eq_zero] at contra
               exact contra
             rw [this] at eq
-            simp [eq] at w_b
-            simp [eq] at w_a
+            simp only [eq, List.getLast_singleton] at w_b
+            simp only [eq, List.head_cons] at w_a
             rw [w_a] at w_b
             apply nmem
             apply w_b
@@ -669,9 +683,9 @@ namespace Graph
               exact this
             · unfold Walk.take
               rw [List.take_getLast w.val w_neq ⟨w.val.length - 1, by apply Nat.lt_succ_of_lt; exact this2⟩]
-              simp
+              simp only [List.get_eq_getElem]
               have this3 : w.val.length - 1 - 1 = w.val.length - 2 := by tauto
-              simp [this3]
+              simp only [this3]
               simp [this]
 
   lemma acyclicIffAllNotReachableFromCycle (G: Graph A): isAcyclic G ↔ ∀ (a:A), ¬ G.reachableFromCycle a := by

--- a/CertifyingDatalog/ModelChecking.lean
+++ b/CertifyingDatalog/ModelChecking.lean
@@ -239,7 +239,7 @@ namespace CheckableModel
       have : ∀ g : Grounding τ, g.applyAtom' pgr.head = pgr.head.toGroundAtom (pgr.head_noVars_of_safe_of_ground safe heq) := by
         intro g
         rw [GroundAtom.eq_iff_toAtom_eq]
-        rw [g.applyAtom'_on_Atom_without_vars_unchanged pgr.head (pgr.head_noVars_of_safe_of_ground safe heq)]
+        rw [g.applyAtom'_on_Atom_without_vars_unchanged (pgr.head_noVars_of_safe_of_ground safe heq)]
         rw [← Atom.toGroundAtom_isSelf]
       split
       case isTrue h =>

--- a/CertifyingDatalog/ModelChecking.lean
+++ b/CertifyingDatalog/ModelChecking.lean
@@ -3,17 +3,17 @@ import CertifyingDatalog.Unification
 import Mathlib.Data.Set.Basic
 import CertifyingDatalog.Basic
 
-structure PartialGroundRule (τ: Signature) [DecidableEq τ.vars] [DecidableEq τ.constants] [DecidableEq τ.relationSymbols] [Inhabited τ.constants] [Hashable τ.constants] [Hashable τ.relationSymbols] [Hashable τ.vars] [ToString τ.constants] [ToString τ.vars] [ToString τ.relationSymbols] where
+structure PartialGroundRule (τ: Signature) where
   head: Atom τ
   groundedBody: List (GroundAtom τ)
   ungroundedBody: List (Atom τ)
 
-abbrev CheckableModel (τ: Signature) [DecidableEq τ.vars] [DecidableEq τ.constants] [DecidableEq τ.relationSymbols] [Inhabited τ.constants] [Hashable τ.constants] [Hashable τ.relationSymbols] [Hashable τ.vars] [ToString τ.constants] [ToString τ.vars] [ToString τ.relationSymbols] := List (GroundAtom τ)
+abbrev CheckableModel (τ: Signature) := List (GroundAtom τ)
 
-variable {τ: Signature} [DecidableEq τ.vars] [DecidableEq τ.constants] [DecidableEq τ.relationSymbols] [Inhabited τ.constants]  [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols] [ToString τ.constants] [ToString τ.vars] [ToString τ.relationSymbols]
+variable {τ: Signature}
 
 namespace PartialGroundRule
-  def isSafe (pgr: PartialGroundRule τ): Prop :=
+  def isSafe [DecidableEq τ.vars] (pgr: PartialGroundRule τ): Prop :=
     pgr.head.vars ⊆ pgr.ungroundedBody.foldl_union Atom.vars ∅
 
   def isGround (pgr: PartialGroundRule τ): Prop :=
@@ -25,131 +25,138 @@ namespace PartialGroundRule
   def toRule (pgr: PartialGroundRule τ) : Rule τ :=
     {head:= pgr.head, body := (pgr.groundedBody.map GroundAtom.toAtom) ++ pgr.ungroundedBody}
 
-  lemma toRule_inv_fromRule (r: Rule τ): (fromRule r).toRule = r := by
+  lemma toRule_inv_fromRule {r: Rule τ}: (fromRule r).toRule = r := by
     unfold fromRule
     unfold toRule
     simp
 
   def isActive (pgr: PartialGroundRule τ) (i: Interpretation τ) : Prop := ∀ (ga: GroundAtom τ), ga ∈ pgr.groundedBody → ga ∈ i
 
-  lemma fromRule_isActive (r: Rule τ) (i: Interpretation τ) : (fromRule r).isActive i := by
+  lemma fromRule_isActive {r: Rule τ} (i: Interpretation τ) : (fromRule r).isActive i := by
     unfold isActive
     unfold fromRule
     simp
 
-  lemma fromRule_safe_iff_rule_safe (r : Rule τ) : (fromRule r).isSafe ↔ r.isSafe := by
+  lemma fromRule_safe_iff_rule_safe [DecidableEq τ.vars] {r : Rule τ} : (fromRule r).isSafe ↔ r.isSafe := by
     unfold isSafe
     unfold Rule.isSafe
     unfold fromRule
     simp
 
-  def isSatisfied (pgr : PartialGroundRule τ) (i : Interpretation τ) : Prop := ∀ (g : Grounding τ), i.satisfiesRule (g.applyRule' pgr.toRule)
+  def isSatisfied [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] (pgr : PartialGroundRule τ) (i : Interpretation τ) : Prop := ∀ (g : Grounding τ), i.satisfiesRule (g.applyRule' pgr.toRule)
 
-  lemma satisfied_iff_of_eq_toRule (pgr1 pgr2: PartialGroundRule τ) (i: Interpretation τ) (h: pgr1.toRule = pgr2.toRule): pgr1.isSatisfied i ↔ pgr2.isSatisfied i := by
+  lemma satisfied_iff_of_eq_toRule [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols]
+      (pgr1 pgr2: PartialGroundRule τ) (i: Interpretation τ) (h: pgr1.toRule = pgr2.toRule): pgr1.isSatisfied i ↔ pgr2.isSatisfied i := by
     unfold isSatisfied
     simp only [h]
 
-  lemma head_noVars_of_safe_of_ground (pgr : PartialGroundRule τ) : pgr.isSafe -> pgr.isGround -> pgr.head.vars = ∅ := by
+  lemma head_noVars_of_safe_of_ground [DecidableEq τ.vars] (pgr : PartialGroundRule τ) : pgr.isSafe -> pgr.isGround -> pgr.head.vars = ∅ := by
     unfold isSafe
     unfold isGround
     intro safe ground
     rw [ground] at safe
     unfold List.foldl_union at safe
-    simp at safe
+    simp only [List.foldl_nil, Finset.subset_empty] at safe
     apply Finset.Subset.antisymm
-    rw [safe]
-    simp
+    · rw [safe]
+    · simp
 
 end PartialGroundRule
 
 namespace Grounding
   def applyPartialGroundRule (g : Grounding τ) (pgr : PartialGroundRule τ) : GroundRule τ := g.applyRule' pgr.toRule
 
-  lemma applyPartialGroundRule_eq_apply_only_ungrounded (g : Grounding τ) (pgr : PartialGroundRule τ) :
+  lemma applyPartialGroundRule_eq_apply_only_ungrounded {g : Grounding τ} {pgr : PartialGroundRule τ} :
     g.applyPartialGroundRule pgr = { head := g.applyAtom' pgr.head, body := pgr.groundedBody ++ pgr.ungroundedBody.map g.applyAtom'} := by
     unfold applyPartialGroundRule
     unfold applyRule'
-    simp [PartialGroundRule.toRule]
+    simp only [PartialGroundRule.toRule, List.map_append, List.map_map, GroundRule.mk.injEq,
+      List.append_cancel_right_eq, true_and]
     apply List.ext_getElem
     · rw [List.length_map]
     · intro _ _ _
-      simp
+      simp only [List.getElem_map, Function.comp_apply]
       rw [applyAtom'_on_GroundAtom_unchanged]
 end Grounding
 
 namespace PartialGroundRule
-  lemma satisfied_of_not_active (pgr: PartialGroundRule τ) (i: Interpretation τ) : ¬ pgr.isActive i -> pgr.isSatisfied i := by
+  variable [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols]
+
+  lemma satisfied_of_not_active {pgr: PartialGroundRule τ} {i: Interpretation τ} : ¬ pgr.isActive i -> pgr.isSatisfied i := by
     intro notActive
     unfold isSatisfied
     intro g
     unfold Interpretation.satisfiesRule
     intro h
     unfold isActive at notActive
-    simp at notActive
-    have apply_eq := g.applyPartialGroundRule_eq_apply_only_ungrounded pgr
+    simp only [not_forall, Classical.not_imp] at notActive
+    have apply_eq := @ g.applyPartialGroundRule_eq_apply_only_ungrounded τ pgr
     unfold Grounding.applyPartialGroundRule at apply_eq
     rw [apply_eq] at h
     unfold GroundRule.bodySet at h
-    simp at h
+    simp only [List.toFinset_append, Finset.coe_union, List.coe_toFinset, List.mem_map,
+      Set.union_subset_iff] at h
     rcases notActive with ⟨a, a_mem_body, a_not_mem_i⟩
     apply False.elim
     apply a_not_mem_i
     apply h.left
-    simp
+    simp only [Set.mem_setOf_eq]
     exact a_mem_body
 end PartialGroundRule
 
 namespace CheckableModel
+  variable [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols]
+
   def substitutionsForAtom (m : CheckableModel τ) (a : Atom τ) : List (Substitution τ) := m.filterMap (fun ga => Substitution.empty.matchAtom a ga)
 
-  lemma noVars_after_applying_substitutionsForAtom (m : CheckableModel τ) (a : Atom τ) : ∀ s ∈ m.substitutionsForAtom a, (s.applyAtom a).vars = ∅ := by
+  lemma noVars_after_applying_substitutionsForAtom {m : CheckableModel τ} {a : Atom τ} : ∀ s ∈ m.substitutionsForAtom a, (s.applyAtom a).vars = ∅ := by
     unfold substitutionsForAtom
     intro s s_mem
-    simp at s_mem
+    simp only [List.mem_filterMap] at s_mem
     rcases s_mem with ⟨ga, _, ga_eq⟩
     have : s = (Substitution.empty.matchAtom a ga).get (by simp [ga_eq]) := by simp [ga_eq]
     rw [this]
     rw [Substitution.matchAtomYieldsSubs]
     exact ga.vars_empty
 
-  lemma substitutionsForAtom_application_in_model (m : CheckableModel τ) (a : Atom τ) : ∀ (h : s ∈ m.substitutionsForAtom a), (s.applyAtom a).toGroundAtom (m.noVars_after_applying_substitutionsForAtom a s h) ∈ m := by
+  lemma substitutionsForAtom_application_in_model {m : CheckableModel τ} {a : Atom τ} : ∀ (h : s ∈ m.substitutionsForAtom a), (s.applyAtom a).toGroundAtom (m.noVars_after_applying_substitutionsForAtom s h) ∈ m := by
     intro h
     unfold substitutionsForAtom at h
-    simp at h
+    simp only [List.mem_filterMap] at h
     rcases h with ⟨ga, ga_mem, ga_eq⟩
     have : s = (Substitution.empty.matchAtom a ga).get (by simp [ga_eq]) := by simp [ga_eq]
-    simp [this]
-    simp [Substitution.matchAtomYieldsSubs]
+    simp only [this]
+    simp only [Substitution.matchAtomYieldsSubs]
     have : ga = ga.toAtom.toGroundAtom ga.vars_empty := by rw [GroundAtom.eq_iff_toAtom_eq]; rw [← ga.toAtom.toGroundAtom_isSelf]
     rw [← this]
     exact ga_mem
 
-  lemma mem_substitutionsForAtom_iff (m : CheckableModel τ) (a : Atom τ) :
+  lemma mem_substitutionsForAtom_iff {m : CheckableModel τ} {a : Atom τ} :
     ∀ (s : Substitution τ), s ∈ m.substitutionsForAtom a ↔ ∃ ga ∈ m, s.applyAtom a = ga ∧ ∀ (s': Substitution τ), s'.applyAtom a = ga → s ⊆ s' := by
     intro s
     constructor
     · intro h
-      exists (s.applyAtom a).toGroundAtom (m.noVars_after_applying_substitutionsForAtom a s h)
+      exists (s.applyAtom a).toGroundAtom (m.noVars_after_applying_substitutionsForAtom s h)
       constructor
       · apply substitutionsForAtom_application_in_model; exact h
-      rw [← Atom.toGroundAtom_isSelf]
-      simp
-      intro s' eq
+      · rw [← Atom.toGroundAtom_isSelf]
+        simp
+        intro s' eq
 
-      unfold substitutionsForAtom at h
-      simp at h
-      rcases h with ⟨ga, _, ga_eq⟩
-      have : s = (Substitution.empty.matchAtom a ga).get (by simp [ga_eq]) := by simp [ga_eq]
+        unfold substitutionsForAtom at h
+        simp only [List.mem_filterMap] at h
+        rcases h with ⟨ga, _, ga_eq⟩
+        have : s = (Substitution.empty.matchAtom a ga).get (by simp [ga_eq]) := by simp [ga_eq]
 
-      rw [this]
-      apply Substitution.matchAtomIsMinimal
-      constructor
-      · apply Substitution.empty_isMinimal
-      · rw [eq, this]; rw [Substitution.matchAtomYieldsSubs]
+        rw [this]
+        apply Substitution.matchAtomIsMinimal
+        constructor
+        · apply Substitution.empty_isMinimal
+        · rw [eq, this]; rw [Substitution.matchAtomYieldsSubs]
     · intro h
       rcases h with ⟨ga, mem, ga_eq, minimal⟩
       unfold substitutionsForAtom
-      simp
+      simp only [List.mem_filterMap]
       exists ga
       constructor
       · exact mem
@@ -158,7 +165,6 @@ namespace CheckableModel
           simp
           apply @Substitution.matchAtomNoneThenNoSubs τ
           rw [eq]
-          simp
           apply Substitution.empty_isMinimal
           apply ga_eq
         | some s' =>
@@ -173,6 +179,8 @@ namespace CheckableModel
           · apply minimal
             rw [this]
             apply Substitution.matchAtomYieldsSubs
+
+  variable [ToString τ.constants] [ToString τ.vars] [ToString τ.relationSymbols]
 
   def checkPGR (m : CheckableModel τ) (pgr : PartialGroundRule τ) (safe : pgr.isSafe) : Except String Unit :=
     match eq : pgr.ungroundedBody with
@@ -200,13 +208,13 @@ namespace CheckableModel
             exact v_in_adj_head.right
 
           rw [eq] at this
-          simp [List.foldl_union] at this
+          simp only [List.foldl_union, List.foldl_cons, Finset.empty_union] at this
           have mem_foldl_union := @List.mem_foldl_union (Atom τ) τ.vars
-          simp [List.foldl_union] at mem_foldl_union
+          simp only [List.foldl_union] at mem_foldl_union
           rw [mem_foldl_union] at this
           cases this with
           | inl v_in_hd =>
-            have noVars_in_hd := m.noVars_after_applying_substitutionsForAtom hd s s_mem
+            have noVars_in_hd := m.noVars_after_applying_substitutionsForAtom s s_mem
             have v_in_applied_hd : v ∈ (s.applyAtom hd).vars := by
               rw [Substitution.applyAtom_remainingVarsNotInDomain]
               rw [Finset.mem_filter_nc]
@@ -232,276 +240,292 @@ namespace CheckableModel
       )
   termination_by pgr.ungroundedBody.length
 
-  lemma checkPGRIsOkIffRuleIsSatisfied (m : CheckableModel τ) (pgr : PartialGroundRule τ) (safe : pgr.isSafe) (active : pgr.isActive m.toSet) : m.checkPGR pgr safe = Except.ok () ↔ pgr.isSatisfied m.toSet := by
+  lemma checkPGRIsOkIffRuleIsSatisfied [Inhabited τ.constants] {m : CheckableModel τ} {pgr : PartialGroundRule τ} (safe : pgr.isSafe) (active : pgr.isActive m.toSet) : m.checkPGR pgr safe = Except.ok () ↔ pgr.isSatisfied m.toSet := by
     unfold checkPGR
     split
-    case h_1 heq =>
-      have : ∀ g : Grounding τ, g.applyAtom' pgr.head = pgr.head.toGroundAtom (pgr.head_noVars_of_safe_of_ground safe heq) := by
-        intro g
-        rw [GroundAtom.eq_iff_toAtom_eq]
-        rw [g.applyAtom'_on_Atom_without_vars_unchanged (pgr.head_noVars_of_safe_of_ground safe heq)]
-        rw [← Atom.toGroundAtom_isSelf]
-      split
-      case isTrue h =>
-        simp
-        unfold PartialGroundRule.isSatisfied
-        unfold Interpretation.satisfiesRule
-        intro g _
-        unfold Grounding.applyRule'
-        unfold PartialGroundRule.toRule
-        simp
-        rw [this]
-        unfold List.toSet
-        simp
-        exact h
-      case isFalse h =>
-        simp
-        unfold PartialGroundRule.isSatisfied
-        unfold Interpretation.satisfiesRule
-        unfold Grounding.applyRule'
-        unfold PartialGroundRule.toRule
-        rw [heq]
-        simp
-        let g : Grounding τ := (fun _ => Inhabited.default (α := τ.constants))
-        exists g
-        unfold GroundRule.bodySet
-        simp
-        constructor
-        · unfold PartialGroundRule.isActive at active
-          intro a a_mem
-          simp at a_mem
-          apply active
-          rcases a_mem with ⟨a', a'_mem, a'_eq⟩
-          rw [g.applyAtom'_on_GroundAtom_unchanged] at a'_eq
-          rw [a'_eq] at a'_mem
-          exact a'_mem
-        · rw[this]
-          unfold List.toSet
+    · case h_1 heq =>
+        have : ∀ g : Grounding τ, g.applyAtom' pgr.head = pgr.head.toGroundAtom (pgr.head_noVars_of_safe_of_ground safe heq) := by
+          intro g
+          rw [GroundAtom.eq_iff_toAtom_eq]
+          rw [g.applyAtom'_on_Atom_without_vars_unchanged (pgr.head_noVars_of_safe_of_ground safe heq)]
+          rw [← Atom.toGroundAtom_isSelf]
+        split
+        case isTrue h =>
           simp
+          unfold PartialGroundRule.isSatisfied
+          unfold Interpretation.satisfiesRule
+          intro g _
+          unfold Grounding.applyRule'
+          unfold PartialGroundRule.toRule
+          simp only
+          rw [this]
+          unfold List.toSet
+          simp only [List.coe_toFinset, Set.mem_setOf_eq]
           exact h
-    case h_2 hd tl heq =>
-      rw [List.mapExceptUnit_iff]
-      simp
-      unfold PartialGroundRule.isSatisfied
-      unfold Interpretation.satisfiesRule
-
-      constructor
-      · intro subs_works
-        unfold Grounding.applyRule'
-        unfold PartialGroundRule.toRule
-        unfold GroundRule.bodySet
-        simp
-        intro g g_active_grounded g_active_ungrounded
-        unfold List.toSet at g_active_grounded
-        simp at g_active_grounded
-        rw [heq] at g_active_ungrounded
-        unfold List.toSet at g_active_ungrounded
-        simp at g_active_ungrounded
-
-        let subs : Substitution τ := (fun v => if v ∈ hd.vars then g v else Option.none)
-
-        have g_after_subs : ∀ a, g.applyAtom' (subs.applyAtom a) = g.applyAtom' a := by
-          intro a
-          unfold Substitution.applyAtom
-          unfold Grounding.applyAtom'
+        case isFalse h =>
           simp
-          intro t t_mem
-          unfold Substitution.applyTerm
-          unfold Grounding.applyTerm'
-          cases t with
-          | constant c => simp
-          | variableDL v =>
-            simp [subs]
-            cases Decidable.em (v ∈ hd.vars) with
-            | inl h => simp [h]
-            | inr h => simp [h]
-
-        have g_eq_subs_on_hd : subs.applyAtom hd = g.applyAtom' hd := by
-          unfold Substitution.applyAtom
-          unfold Grounding.applyAtom'
-          unfold GroundAtom.toAtom
-          simp
-          intro t t_mem
-          unfold Substitution.applyTerm
-          unfold Grounding.applyTerm'
-          cases t with
-          | constant c => simp
-          | variableDL v =>
-            have : v ∈ hd.vars := by
-              unfold Atom.vars
-              rw [List.mem_foldl_union]
-              apply Or.inr
-              exists Term.variableDL v
-              unfold Term.vars
-              constructor
-              · exact t_mem
-              · simp
-            simp [subs, this]
-
-        have subs_domain : subs.domain = hd.vars := by
-          unfold Substitution.domain
-          apply Set.ext
-          intro v
-          simp [subs]
-
-        specialize subs_works subs (by
-          rw [mem_substitutionsForAtom_iff]
-          exists g.applyAtom' hd
+          unfold PartialGroundRule.isSatisfied
+          unfold Interpretation.satisfiesRule
+          unfold Grounding.applyRule'
+          unfold PartialGroundRule.toRule
+          rw [heq]
+          simp only [List.append_nil, List.map_map, not_forall, Classical.not_imp]
+          let g : Grounding τ := (fun _ => Inhabited.default (α := τ.constants))
+          exists g
+          unfold GroundRule.bodySet
+          simp only [List.coe_toFinset, List.mem_map, Function.comp_apply]
           constructor
-          · apply g_active_ungrounded; apply Or.inl; rfl
-          constructor
-          · exact g_eq_subs_on_hd
-          · intro s' s'_apply_also_ground
-            rw [← g_eq_subs_on_hd] at s'_apply_also_ground
-            intro v v_in_dom
-            rw [subs_domain] at v_in_dom
-            simp at v_in_dom
-            unfold Substitution.applyAtom at s'_apply_also_ground
-            simp at s'_apply_also_ground
-            specialize s'_apply_also_ground (Term.variableDL v) (by
-              unfold Atom.vars at v_in_dom
-              rw [List.mem_foldl_union] at v_in_dom
-              cases v_in_dom; contradiction;
-              case inr h =>
-              rcases h with ⟨t, t_mem, v_in_t⟩
-              unfold Term.vars at v_in_t
-              cases t <;> simp at v_in_t
-              rw [v_in_t]
-              exact t_mem
-            )
-            unfold Substitution.applyTerm at s'_apply_also_ground
-            simp [subs, v_in_dom] at s'_apply_also_ground
-            simp [subs, v_in_dom]
-            cases eq : s' v with
-            | none => simp [eq] at s'_apply_also_ground
-            | some c =>
-              simp [eq] at s'_apply_also_ground
-              rw [s'_apply_also_ground]
-        )
-        have _termination : tl.length < pgr.ungroundedBody.length := by rw [heq]; simp
-        rw [m.checkPGRIsOkIffRuleIsSatisfied _ _ (by
-          unfold PartialGroundRule.isActive
-          unfold List.toSet
-          simp
-          intro ga ga_eq
-          cases ga_eq with
-          | inl ga_eq =>
-            specialize g_active_grounded ga
-            rw [Grounding.applyAtom'_on_GroundAtom_unchanged] at g_active_grounded
-            apply g_active_grounded
-            exact ga_eq
-          | inr ga_eq =>
-            apply g_active_ungrounded
-            apply Or.inl
-            rw [ga_eq]
-            rw [GroundAtom.eq_iff_toAtom_eq]
-            rw [← Atom.toGroundAtom_isSelf]
-            rw [g_eq_subs_on_hd]
-        )] at subs_works
-        unfold PartialGroundRule.isSatisfied at subs_works
-        unfold Interpretation.satisfiesRule at subs_works
-        unfold PartialGroundRule.toRule at subs_works
-        unfold GroundRule.bodySet at subs_works
-        unfold Grounding.applyRule' at subs_works
-        simp at subs_works
-        specialize subs_works g
-        rw [g_after_subs] at subs_works
-        apply subs_works
-        unfold List.toSet
-        rw [Set.subset_def]
-        simp
-        constructor
-        · rw [← (subs.applyAtom hd).toGroundAtom_isSelf]; rw [g_after_subs]; apply g_active_ungrounded; apply Or.inl; rfl
-        intro a h
-        cases h with
-        | inl h =>
-          rcases h with ⟨b, h⟩
-          rw [← h.right]
-          apply g_active_grounded
-          exact h.left
-        | inr h =>
-          rcases h with ⟨b, h⟩
-          rw [← h.right]
-          apply g_active_ungrounded
-          apply Or.inr
-          exists b
-          rw [g_after_subs]
-          simp
-          exact h.left
-      · intro grounding_works
-        intro subs subs_mem
-        have _termination : tl.length < pgr.ungroundedBody.length := by rw [heq]; simp
-        rw [m.checkPGRIsOkIffRuleIsSatisfied _ _ (by
-          unfold PartialGroundRule.isActive
-          unfold List.toSet
-          simp
-          intro ga h
-          cases h with
-          | inl h =>
-            unfold PartialGroundRule.isActive at active
-            unfold List.toSet at active
-            simp at active
-            apply active
+          · rw[this]
+            unfold List.toSet
+            simp only [List.coe_toFinset, Set.mem_setOf_eq]
             exact h
-          | inr h =>
-            rw [h]
-            apply substitutionsForAtom_application_in_model
-            exact subs_mem
-        )]
+          · unfold PartialGroundRule.isActive at active
+            intro a a_mem
+            simp only [Set.mem_setOf_eq] at a_mem
+            apply active
+            rcases a_mem with ⟨a', a'_mem, a'_eq⟩
+            rw [g.applyAtom'_on_GroundAtom_unchanged] at a'_eq
+            rw [a'_eq] at a'_mem
+            exact a'_mem
+    · case h_2 hd tl heq =>
+        rw [List.mapExceptUnit_iff]
+        simp
         unfold PartialGroundRule.isSatisfied
         unfold Interpretation.satisfiesRule
-        unfold Grounding.applyRule'
-        unfold PartialGroundRule.toRule
-        unfold List.toSet
-        unfold GroundRule.bodySet
-        simp
-        intro g h
-        rw [Set.subset_def] at h
-        simp at h
-        unfold List.toSet at grounding_works
-        unfold PartialGroundRule.toRule at grounding_works
-        unfold Grounding.applyRule' at grounding_works
-        unfold GroundRule.bodySet at grounding_works
-        simp at grounding_works
 
-        let grounding : Grounding τ := fun v => (subs v).getD (g v)
-
-        have : ∀ a, grounding.applyAtom' a = g.applyAtom' (subs.applyAtom a) := by
-          intro a
-          simp [grounding]
-          unfold Grounding.applyAtom'
-          unfold Substitution.applyAtom
-          simp
-          intro t t_mem
-          unfold Substitution.applyTerm
-          unfold Grounding.applyTerm'
-          cases t with
-          | constant _ => simp
-          | variableDL v => simp; cases subs v <;> simp
-
-        specialize grounding_works grounding
-        rw [this] at grounding_works
-        apply grounding_works
-        intro ga ga_mem
-        rw [Grounding.applyAtom'_on_GroundAtom_unchanged]
-        apply h.right
-        apply Or.inl
-        exists ga
-        rw [Grounding.applyAtom'_on_GroundAtom_unchanged]
-        simp
-        exact ga_mem
-        rw [heq]
-        rw [← Atom.toGroundAtom_isSelf] at h
-        simp
         constructor
-        · rw [this]; exact h.left
-        intro a a_mem
-        apply h.right
-        apply Or.inr
-        exists a
-        rw [this]
-        simp
-        exact a_mem
+        · intro subs_works
+          unfold Grounding.applyRule'
+          unfold PartialGroundRule.toRule
+          unfold GroundRule.bodySet
+          simp only [List.map_append, List.map_map, List.toFinset_append, Finset.coe_union,
+            List.coe_toFinset, List.mem_map, Function.comp_apply, Set.union_subset_iff, and_imp]
+          intro g g_active_grounded g_active_ungrounded
+          unfold List.toSet at g_active_grounded
+          simp only [List.coe_toFinset, Set.setOf_subset_setOf, forall_exists_index, and_imp,
+            forall_apply_eq_imp_iff₂] at g_active_grounded
+          rw [heq] at g_active_ungrounded
+          unfold List.toSet at g_active_ungrounded
+          simp only [List.mem_cons, exists_eq_or_imp, List.coe_toFinset,
+            Set.setOf_subset_setOf] at g_active_ungrounded
+
+          let subs : Substitution τ := (fun v => if v ∈ hd.vars then g v else Option.none)
+
+          have g_after_subs : ∀ a, g.applyAtom' (subs.applyAtom a) = g.applyAtom' a := by
+            intro a
+            unfold Substitution.applyAtom
+            unfold Grounding.applyAtom'
+            simp only [List.map_map, GroundAtom.mk.injEq, List.map_inj_left, Function.comp_apply,
+              true_and]
+            intro t t_mem
+            unfold Substitution.applyTerm
+            unfold Grounding.applyTerm'
+            cases t with
+            | constant c => simp
+            | variableDL v =>
+              simp only [subs]
+              cases Decidable.em (v ∈ hd.vars) with
+              | inl h => simp [h]
+              | inr h => simp [h]
+
+          have g_eq_subs_on_hd : subs.applyAtom hd = g.applyAtom' hd := by
+            unfold Substitution.applyAtom
+            unfold Grounding.applyAtom'
+            unfold GroundAtom.toAtom
+            simp only [List.map_map, Atom.mk.injEq, List.map_inj_left, Function.comp_apply,
+              true_and, subs]
+            intro t t_mem
+            unfold Substitution.applyTerm
+            unfold Grounding.applyTerm'
+            cases t with
+            | constant c => simp
+            | variableDL v =>
+              have : v ∈ hd.vars := by
+                unfold Atom.vars
+                rw [List.mem_foldl_union]
+                apply Or.inr
+                exists Term.variableDL v
+                unfold Term.vars
+                constructor
+                · exact t_mem
+                · simp only [Finset.mem_singleton, subs]
+              simp [subs, this]
+
+          have subs_domain : subs.domain = hd.vars := by
+            unfold Substitution.domain
+            apply Set.ext
+            intro v
+            simp only [Option.isSome_ite, Finset.setOf_mem, Finset.mem_coe, subs]
+
+          specialize subs_works subs (by
+            rw [mem_substitutionsForAtom_iff]
+            exists g.applyAtom' hd
+            constructor
+            · apply g_active_ungrounded; apply Or.inl; rfl
+            constructor
+            · exact g_eq_subs_on_hd
+            · intro s' s'_apply_also_ground
+              rw [← g_eq_subs_on_hd] at s'_apply_also_ground
+              intro v v_in_dom
+              rw [subs_domain] at v_in_dom
+              simp only [Finset.mem_coe, subs] at v_in_dom
+              unfold Substitution.applyAtom at s'_apply_also_ground
+              simp only [Atom.mk.injEq, List.map_inj_left, true_and, subs] at s'_apply_also_ground
+              specialize s'_apply_also_ground (Term.variableDL v) (by
+                unfold Atom.vars at v_in_dom
+                rw [List.mem_foldl_union] at v_in_dom
+                cases v_in_dom; contradiction;
+                case inr h =>
+                rcases h with ⟨t, t_mem, v_in_t⟩
+                unfold Term.vars at v_in_t
+                cases t <;> simp at v_in_t
+                rw [v_in_t]
+                exact t_mem
+              )
+              unfold Substitution.applyTerm at s'_apply_also_ground
+              simp only [v_in_dom, ↓reduceIte, subs] at s'_apply_also_ground
+              simp only [v_in_dom, ↓reduceIte, subs]
+              cases eq : s' v with
+              | none => simp [eq] at s'_apply_also_ground
+              | some c =>
+                simp only [eq, Term.constant.injEq, subs] at s'_apply_also_ground
+                rw [s'_apply_also_ground]
+          )
+          have _termination : tl.length < pgr.ungroundedBody.length := by rw [heq]; simp
+          rw [m.checkPGRIsOkIffRuleIsSatisfied _ (by
+            unfold PartialGroundRule.isActive
+            unfold List.toSet
+            simp
+            intro ga ga_eq
+            cases ga_eq with
+            | inl ga_eq =>
+              specialize g_active_grounded ga
+              rw [Grounding.applyAtom'_on_GroundAtom_unchanged] at g_active_grounded
+              apply g_active_grounded
+              exact ga_eq
+            | inr ga_eq =>
+              apply g_active_ungrounded
+              apply Or.inl
+              rw [ga_eq]
+              rw [GroundAtom.eq_iff_toAtom_eq]
+              rw [← Atom.toGroundAtom_isSelf]
+              rw [g_eq_subs_on_hd]
+          )] at subs_works
+          unfold PartialGroundRule.isSatisfied at subs_works
+          unfold Interpretation.satisfiesRule at subs_works
+          unfold PartialGroundRule.toRule at subs_works
+          unfold GroundRule.bodySet at subs_works
+          unfold Grounding.applyRule' at subs_works
+          simp only [List.map_append, List.map_cons, List.map_nil, List.append_assoc,
+            List.singleton_append, List.map_map, List.toFinset_append, List.toFinset_cons,
+            Finset.union_insert, Finset.coe_insert, Finset.coe_union, List.coe_toFinset,
+            List.mem_map, Function.comp_apply, subs] at subs_works
+          specialize subs_works g
+          rw [g_after_subs] at subs_works
+          apply subs_works
+          unfold List.toSet
+          rw [Set.subset_def]
+          simp only [Set.mem_insert_iff, Set.mem_union, Set.mem_setOf_eq, List.coe_toFinset,
+            forall_eq_or_imp, subs]
+          constructor
+          · rw [← (subs.applyAtom hd).toGroundAtom_isSelf]; rw [g_after_subs]; apply g_active_ungrounded; apply Or.inl; rfl
+          · intro a h
+            cases h with
+            | inl h =>
+              rcases h with ⟨b, h⟩
+              rw [← h.right]
+              apply g_active_grounded
+              exact h.left
+            | inr h =>
+              rcases h with ⟨b, h⟩
+              rw [← h.right]
+              apply g_active_ungrounded
+              apply Or.inr
+              exists b
+              rw [g_after_subs]
+              simp only [and_true, subs]
+              exact h.left
+        · intro grounding_works
+          intro subs subs_mem
+          have _termination : tl.length < pgr.ungroundedBody.length := by rw [heq]; simp
+          rw [m.checkPGRIsOkIffRuleIsSatisfied _ (by
+            unfold PartialGroundRule.isActive
+            unfold List.toSet
+            simp only [List.mem_append, List.mem_singleton, List.coe_toFinset, Set.mem_setOf_eq]
+            intro ga h
+            cases h with
+            | inl h =>
+              unfold PartialGroundRule.isActive at active
+              unfold List.toSet at active
+              simp only [List.coe_toFinset, Set.mem_setOf_eq] at active
+              apply active
+              exact h
+            | inr h =>
+              rw [h]
+              apply substitutionsForAtom_application_in_model
+              exact subs_mem
+          )]
+          unfold PartialGroundRule.isSatisfied
+          unfold Interpretation.satisfiesRule
+          unfold Grounding.applyRule'
+          unfold PartialGroundRule.toRule
+          unfold List.toSet
+          unfold GroundRule.bodySet
+          simp only [List.map_append, List.map_cons, List.map_nil, List.append_assoc,
+            List.singleton_append, List.map_map, List.toFinset_append, List.toFinset_cons,
+            Finset.union_insert, Finset.coe_insert, Finset.coe_union, List.coe_toFinset,
+            List.mem_map, Function.comp_apply, Set.mem_setOf_eq]
+          intro g h
+          rw [Set.subset_def] at h
+          simp only [Set.mem_insert_iff, Set.mem_union, Set.mem_setOf_eq, forall_eq_or_imp] at h
+          unfold List.toSet at grounding_works
+          unfold PartialGroundRule.toRule at grounding_works
+          unfold Grounding.applyRule' at grounding_works
+          unfold GroundRule.bodySet at grounding_works
+          simp only [List.map_append, List.map_map, List.toFinset_append, Finset.coe_union,
+            List.coe_toFinset, List.mem_map, Function.comp_apply, Set.union_subset_iff,
+            Set.setOf_subset_setOf, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂,
+            Set.mem_setOf_eq] at grounding_works
+
+          let grounding : Grounding τ := fun v => (subs v).getD (g v)
+
+          have : ∀ a, grounding.applyAtom' a = g.applyAtom' (subs.applyAtom a) := by
+            intro a
+            simp only [grounding]
+            unfold Grounding.applyAtom'
+            unfold Substitution.applyAtom
+            simp only [List.map_map, GroundAtom.mk.injEq, List.map_inj_left, Function.comp_apply,
+              true_and, grounding]
+            intro t t_mem
+            unfold Substitution.applyTerm
+            unfold Grounding.applyTerm'
+            cases t with
+            | constant _ => simp
+            | variableDL v => simp; cases subs v <;> simp
+
+          specialize grounding_works grounding
+          rw [this] at grounding_works
+          apply grounding_works
+          · intro ga ga_mem
+            rw [Grounding.applyAtom'_on_GroundAtom_unchanged]
+            apply h.right
+            apply Or.inl
+            exists ga
+            rw [Grounding.applyAtom'_on_GroundAtom_unchanged]
+            simp only [and_true, grounding]
+            exact ga_mem
+          · rw [heq]
+            rw [← Atom.toGroundAtom_isSelf] at h
+            simp only [List.mem_cons, forall_eq_or_imp]
+            constructor
+            · rw [this]; exact h.left
+            · intro a a_mem
+              apply h.right
+              apply Or.inr
+              exists a
+              rw [this]
+              simp only [and_true]
+              exact a_mem
   termination_by pgr.ungroundedBody.length
 
   def checkProgram (m : CheckableModel τ) (p : Program τ) (safe : p.isSafe) : Except String Unit :=
@@ -512,22 +536,23 @@ namespace CheckableModel
       exact r_mem
     ))
 
-  theorem checkProgramIsOkIffAllRulesAreSatisfied (m : CheckableModel τ) (p : Program τ) (safe : p.isSafe) :
+  theorem checkProgramIsOkIffAllRulesAreSatisfied [Inhabited τ.constants] {m : CheckableModel τ} {p : Program τ} (safe : p.isSafe) :
     m.checkProgram p safe = Except.ok () ↔ ∀ r ∈ p.groundProgram, Interpretation.satisfiesRule m.toSet r := by
       unfold checkProgram
       rw [List.mapExceptUnit_iff]
       unfold Program.groundProgram
-      simp
+      simp only [List.mem_attach, forall_const, Subtype.forall, exists_and_left, Set.mem_setOf_eq,
+        forall_exists_index, and_imp]
       constructor
       · intro h gr r r_mem g eq
         specialize h r r_mem
-        rw [m.checkPGRIsOkIffRuleIsSatisfied _ _ (by apply PartialGroundRule.fromRule_isActive)] at h
+        rw [m.checkPGRIsOkIffRuleIsSatisfied _ (by apply PartialGroundRule.fromRule_isActive)] at h
         unfold PartialGroundRule.isSatisfied at h
         rw [PartialGroundRule.toRule_inv_fromRule] at h
         rw [eq]
         apply h
       · intro h r r_mem
-        rw [m.checkPGRIsOkIffRuleIsSatisfied _ _ (by apply PartialGroundRule.fromRule_isActive)]
+        rw [m.checkPGRIsOkIffRuleIsSatisfied _ (by apply PartialGroundRule.fromRule_isActive)]
         unfold PartialGroundRule.isSatisfied
         rw [PartialGroundRule.toRule_inv_fromRule]
         intro g

--- a/CertifyingDatalog/Parsing.lean
+++ b/CertifyingDatalog/Parsing.lean
@@ -89,7 +89,7 @@ namespace ParseArityHelper
         arity := (fun x =>
           if q:(x = symbol)
           then arity
-          else helper.arity ⟨x, by have prop := x.prop; simp [q] at prop; exact prop⟩
+          else helper.arity ⟨x, by have prop := x.prop; simp[q] at prop; exact prop⟩
         )
       }
 
@@ -284,16 +284,16 @@ namespace InputOrderedGraph
           (edge.label.toGroundAtom helper).map (fun label =>
             ⟨graph.val.push ⟨label, edge.predecessors⟩, by
               intro ⟨i, i_lt⟩
-              simp at i_lt
+              simp only [Fin.getElem_fin, Array.size_push] at i_lt
               cases Decidable.em (i < graph.val.size) with
               | inl i_lt_g =>
-                simp
+                simp only [Fin.getElem_fin]
                 rw [Array.getElem_push_lt]
                 apply graph.prop ⟨i, i_lt_g⟩
               | inr i_not_lt_g =>
                 have : i = graph.val.size := by cases Nat.le_iff_lt_or_eq.mp (Nat.le_of_lt_succ i_lt); contradiction; assumption
-                simp [this]
-                simp at h
+                simp only [Fin.getElem_fin, this, Array.getElem_push_eq]
+                simp only [Fin.getElem_fin, List.all_eq_true, decide_eq_true_eq] at h
                 exact h
             ⟩
           )

--- a/CertifyingDatalog/TreeValidation.lean
+++ b/CertifyingDatalog/TreeValidation.lean
@@ -2,6 +2,7 @@ import CertifyingDatalog.Basic
 import CertifyingDatalog.Datalog
 import CertifyingDatalog.Unification
 
+section SymbolSequenceMap
 def SymbolSequenceMap (τ : Signature) [DecidableEq τ.vars] [DecidableEq τ.constants] [DecidableEq τ.relationSymbols] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols] :=
   Std.HashMap (List τ.relationSymbols) (List (Rule τ))
 
@@ -11,10 +12,11 @@ def SymbolSequenceMap.empty : SymbolSequenceMap τ := Std.HashMap.empty
 
 def SymbolSequenceMap.find (m : SymbolSequenceMap τ) (l : List (τ.relationSymbols)) : List (Rule τ) := m.getD l []
 
+end SymbolSequenceMap
 namespace Rule
   def symbolSequence (r: Rule τ): List τ.relationSymbols := r.head.symbol :: (List.map Atom.symbol r.body)
 
-  lemma symbolSequence_eq_matchingGroundRule (r: Rule τ) (gr: GroundRule τ) (match_r: ∃ (s: Substitution τ), s.applyRule r = gr): r.symbolSequence = gr.toRule.symbolSequence := by
+  lemma symbolSequence_eq_matchingGroundRule {r: Rule τ} {gr: GroundRule τ} (match_r: ∃ (s: Substitution τ), s.applyRule r = gr): r.symbolSequence = gr.toRule.symbolSequence := by
     rcases match_r with ⟨s, apply_s⟩
     rw [← apply_s]
     unfold Substitution.applyRule
@@ -22,25 +24,28 @@ namespace Rule
     unfold symbolSequence
     simp
 
-  lemma ne_of_symbolSequence_ne (r1 r2 : Rule τ) (h : r1.symbolSequence ≠ r2.symbolSequence) : ∀ (s : Substitution τ), s.applyRule r1 ≠ r2 := by
+  lemma ne_of_symbolSequence_ne {r1 r2 : Rule τ} (h : r1.symbolSequence ≠ r2.symbolSequence) : ∀ (s : Substitution τ), s.applyRule r1 ≠ r2 := by
     intro s apply_s
     apply h
     rw [← apply_s]
     unfold symbolSequence
-    simp
+    simp only [List.cons.injEq]
     unfold Substitution.applyRule
     unfold Substitution.applyAtom
     simp
 
-  lemma body_length_eq_of_symbolSequence_eq (r1 r2: Rule τ) (h: r1.symbolSequence = r2.symbolSequence): r1.body.length = r2.body.length := by
+  lemma body_length_eq_of_symbolSequence_eq {r1 r2: Rule τ} (h: r1.symbolSequence = r2.symbolSequence): r1.body.length = r2.body.length := by
     unfold symbolSequence at h
-    simp at h
+    simp only [List.cons.injEq] at h
     rcases h with ⟨_, body⟩
     rw [← r1.body.length_map Atom.symbol, ← r2.body.length_map Atom.symbol]
     rw [body]
 end Rule
 
 namespace Program
+  variable {τ: Signature} [DecidableEq τ.vars] [DecidableEq τ.constants] [DecidableEq τ.relationSymbols] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
+
+
   def toSymbolSequenceMap_aux (init : SymbolSequenceMap τ) : Program τ -> SymbolSequenceMap τ
   | .nil => init
   | .cons rule p =>
@@ -50,7 +55,7 @@ namespace Program
 
   def toSymbolSequenceMap (p : Program τ) := p.toSymbolSequenceMap_aux SymbolSequenceMap.empty
 
-  lemma toSymbolSequenceMap_mem (init : SymbolSequenceMap τ) (p : Program τ) : ∀ (l : List (τ.relationSymbols)) (r : Rule τ), r ∈ ((p.toSymbolSequenceMap_aux init).find l) ↔ r ∈ (init.find l) ∨ (r.symbolSequence = l ∧ r ∈ p) := by
+  lemma toSymbolSequenceMap_mem {init : SymbolSequenceMap τ} {p : Program τ} : ∀ (l : List (τ.relationSymbols)) (r : Rule τ), r ∈ ((p.toSymbolSequenceMap_aux init).find l) ↔ r ∈ (init.find l) ∨ (r.symbolSequence = l ∧ r ∈ p) := by
     induction p generalizing init with
     | nil =>
       intros
@@ -59,13 +64,13 @@ namespace Program
     | cons rule p ih =>
       intro l r
       unfold toSymbolSequenceMap_aux
-      simp
+      simp only [List.mem_cons]
       rw [ih]
       by_cases l_symb: l = rule.symbolSequence
-      · simp [l_symb]
+      · simp only [l_symb]
         unfold SymbolSequenceMap.find
         rw [Std.HashMap.getD_insert_self]
-        simp
+        simp only [List.mem_cons]
         tauto
       · unfold SymbolSequenceMap.find
         rw [Std.HashMap.getD_insert]
@@ -98,50 +103,51 @@ namespace Program
             | inr r_tl =>
               apply r_tl
 
-  lemma toSymbolSequenceMap_semantics (p: Program τ) (r: Rule τ) : ∀ (r': Rule τ), r' ∈ (p.toSymbolSequenceMap.find r.symbolSequence) ↔ r' ∈ p ∧ r'.symbolSequence = r.symbolSequence := by
+  lemma toSymbolSequenceMap_semantics {p: Program τ} {r: Rule τ} : ∀ (r': Rule τ), r' ∈ (p.toSymbolSequenceMap.find r.symbolSequence) ↔ r' ∈ p ∧ r'.symbolSequence = r.symbolSequence := by
     intro r'
     unfold toSymbolSequenceMap
     rw [toSymbolSequenceMap_mem]
-    simp [SymbolSequenceMap.empty, SymbolSequenceMap.find]
+    simp only [SymbolSequenceMap.find, SymbolSequenceMap.empty, Std.HashMap.getD_empty,
+      List.not_mem_nil, false_or]
     rw [And.comm]
 end Program
-
-variable [ToString τ.constants] [ToString τ.vars] [ToString τ.relationSymbols]
+variable {τ: Signature} [DecidableEq τ.vars] [DecidableEq τ.constants] [DecidableEq τ.relationSymbols]
+  [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
+  [ToString τ.constants] [ToString τ.vars] [ToString τ.relationSymbols]
 
 def checkRuleMatch (m: SymbolSequenceMap τ) (gr: GroundRule τ): Except String Unit :=
   if (m.find gr.toRule.symbolSequence).any (fun rule => (Substitution.matchRule rule gr).isSome)
   then Except.ok ()
   else Except.error ("No match for " ++ ToString.toString gr)
 
-lemma checkRuleMatchOkIffExistsRule [Inhabited τ.constants] (p: Program τ) (gr: GroundRule τ): checkRuleMatch p.toSymbolSequenceMap gr = Except.ok () ↔ ∃ (r: Rule τ) (g: Grounding τ), r ∈ p ∧ g.applyRule' r = gr :=
+lemma checkRuleMatchOkIffExistsRule [Inhabited τ.constants] {p: Program τ} {gr: GroundRule τ} : checkRuleMatch p.toSymbolSequenceMap gr = Except.ok () ↔ ∃ (r: Rule τ) (g: Grounding τ), r ∈ p ∧ g.applyRule' r = gr :=
 by
   simp [grounding_substitution_equiv]
   unfold checkRuleMatch
   split
-  rename_i symbolSequenceMatch
-  simp
-  simp at symbolSequenceMatch
-  simp_rw [Program.toSymbolSequenceMap_semantics] at symbolSequenceMatch
-  rcases symbolSequenceMatch with ⟨r, h, s⟩
-  use r
-  simp [h]
-  use (Substitution.matchRule r gr).get s
-  apply Substitution.matchRuleYieldsSubs
-
-  rename_i symbolSequenceMatch
-  simp at *
-  simp_rw [Program.toSymbolSequenceMap_semantics] at symbolSequenceMatch
-  intro r rP
-  specialize symbolSequenceMatch r
-  cases (Decidable.em (r.symbolSequence = gr.toRule.symbolSequence)) with
-  | inl eq =>
-    simp [rP, eq] at symbolSequenceMatch
-    apply Substitution.matchRuleNoneThenNoSubs
-    simp
-    apply symbolSequenceMatch
-  | inr neq =>
-    apply Rule.ne_of_symbolSequence_ne
-    apply neq
+  · rename_i symbolSequenceMatch
+    simp only [true_iff]
+    simp only [List.any_eq_true] at symbolSequenceMatch
+    simp_rw [Program.toSymbolSequenceMap_semantics] at symbolSequenceMatch
+    rcases symbolSequenceMatch with ⟨r, h, s⟩
+    use r
+    simp only [h, true_and]
+    use (Substitution.matchRule r gr).get s
+    apply Substitution.matchRuleYieldsSubs
+  · rename_i symbolSequenceMatch
+    simp only [List.any_eq_true, not_exists, not_and, Bool.not_eq_true, Option.not_isSome,
+      Option.isNone_iff_eq_none, reduceCtorEq, false_iff, ne_eq] at *
+    simp_rw [Program.toSymbolSequenceMap_semantics] at symbolSequenceMatch
+    intro r rP
+    specialize symbolSequenceMatch r
+    cases (Decidable.em (r.symbolSequence = gr.toRule.symbolSequence)) with
+    | inl eq =>
+      simp only [rP, eq, and_self, forall_const] at symbolSequenceMatch
+      apply Substitution.matchRuleNoneThenNoSubs
+      apply symbolSequenceMatch
+    | inr neq =>
+      apply Rule.ne_of_symbolSequence_ne
+      apply neq
 
 namespace ProofTreeSkeleton
   def checkValidity (t : ProofTreeSkeleton τ) (m : SymbolSequenceMap τ) (d : Database τ) : Except String Unit :=
@@ -160,7 +166,7 @@ namespace ProofTreeSkeleton
         | Except.error msg => Except.error msg
   termination_by sizeOf t
 
-  lemma checkValidityOkIffIsValid [Inhabited τ.constants] (t: ProofTreeSkeleton τ) (kb: KnowledgeBase τ) : t.checkValidity kb.prog.toSymbolSequenceMap kb.db = Except.ok () ↔ t.isValid kb :=
+  lemma checkValidityOkIffIsValid [Inhabited τ.constants] {t: ProofTreeSkeleton τ} {kb: KnowledgeBase τ} : t.checkValidity kb.prog.toSymbolSequenceMap kb.db = Except.ok () ↔ t.isValid kb :=
   by
     induction' h_t : t.height using Nat.strongRecOn with n ih generalizing t
     cases t with
@@ -172,50 +178,50 @@ namespace ProofTreeSkeleton
         by_cases contains_a: kb.db.contains a
         · rw [if_pos contains_a]
           constructor
-          intro _
-          right
-          rw [← List.isEmpty_iff]
-          constructor
-          exact emptyL
-          exact contains_a
-          simp
+          · intro _
+            right
+            rw [← List.isEmpty_iff]
+            constructor
+            · exact emptyL
+            · exact contains_a
+          · simp
         · rw [if_neg contains_a]
           split
-          simp
-          rename_i u checkRuleMatch
-          rw [checkRuleMatchOkIffExistsRule] at checkRuleMatch
-          left
-          rw [List.isEmpty_iff] at emptyL
-          rcases checkRuleMatch with ⟨r, g, rP, apply_g⟩
-          use r
-          constructor
-          apply rP
-          constructor
-          use g
-          rw [emptyL]
-          simp
-          exact apply_g
+          · simp only [exists_and_left, exists_and_right, true_iff]
+            rename_i u checkRuleMatch
+            rw [checkRuleMatchOkIffExistsRule] at checkRuleMatch
+            left
+            rw [List.isEmpty_iff] at emptyL
+            rcases checkRuleMatch with ⟨r, g, rP, apply_g⟩
+            use r
+            constructor
+            · apply rP
+            · constructor
+              · use g
+                rw [emptyL]
+                simp only [List.map_nil]
+                exact apply_g
+              · rw [emptyL]
+                unfold List.Forall
+                simp
+          · simp only [reduceCtorEq, exists_and_left, exists_and_right, false_iff, not_or,
+            not_exists, not_and, forall_exists_index, Bool.not_eq_true]
+            rename_i checkRuleMatchResult
+            rw [List.isEmpty_iff] at emptyL
 
-          rw [emptyL]
-          unfold List.Forall
-          simp
+            have checkRuleMatch': ¬ checkRuleMatch kb.prog.toSymbolSequenceMap { head := a, body := [] } = Except.ok () := by
+              rw [checkRuleMatchResult]
+              simp
+            rw [checkRuleMatchOkIffExistsRule] at checkRuleMatch'
+            simp only [exists_and_left, not_exists, not_and, ne_eq] at checkRuleMatch'
+            constructor
+            · rw [emptyL]
+              simp only [List.map_nil, List.attach_nil, List.Forall, not_true_eq_false, imp_false,
+                ne_eq]
+              apply checkRuleMatch'
+            · simp [contains_a]
 
-          simp
-          rename_i checkRuleMatchResult
-          rw [List.isEmpty_iff] at emptyL
-
-          have checkRuleMatch': ¬ checkRuleMatch kb.prog.toSymbolSequenceMap { head := a, body := [] } = Except.ok () := by
-            rw [checkRuleMatchResult]
-            simp
-          rw [checkRuleMatchOkIffExistsRule] at checkRuleMatch'
-          simp at checkRuleMatch'
-          constructor
-          rw [emptyL]
-          simp
-          apply checkRuleMatch'
-          simp [contains_a]
-
-      · simp[emptyL]
+      · simp only [emptyL, Bool.false_eq_true, ↓reduceIte, exists_and_left, exists_and_right]
         split
         · rename_i checkRuleMatchResult
           rw [checkRuleMatchOkIffExistsRule] at checkRuleMatchResult
@@ -226,53 +232,49 @@ namespace ProofTreeSkeleton
             left
             use r
             constructor
-            apply rP
-            constructor
-            use g
-            rw [List.forall_iff_forall_mem]
-            simp
-            intro t t_mem
-            specialize ih t.height
-            have height_t: t.height < n := by
-              rw [← h_t]
-              apply Tree.heightOfMemberIsSmaller
-              unfold Tree.member
-              simp [t_mem]
-            specialize ih height_t t
-            simp at ih
-            rw [← ih]
-            simp at h
-            specialize h t t_mem
-            apply h
-
+            · apply rP
+            · constructor
+              · use g
+              · rw [List.forall_iff_forall_mem]
+                simp only [List.mem_attach, forall_const, Subtype.forall]
+                intro t t_mem
+                specialize ih t.height
+                have height_t: t.height < n := by
+                  rw [← h_t]
+                  apply Tree.heightOfMemberIsSmaller
+                  unfold Tree.member
+                  simp [t_mem]
+                simp only [List.mem_attach, forall_const, Subtype.forall] at h
+                specialize h t t_mem
+                rw [ih height_t rfl] at h
+                exact h
           · intro h
-            simp
+            simp only [List.mem_attach, forall_const, Subtype.forall]
             intro t t_mem
             specialize ih t.height
             have height_t: t.height < n := by
               rw [← h_t]
               apply Tree.heightOfMemberIsSmaller
               simp [Tree.member, t_mem]
-            specialize ih height_t t
-            simp at ih
-            rw [ih]
+            rw [ih height_t rfl]
             rw [List.isEmpty_iff] at emptyL
-            simp [emptyL] at h
+            simp only [emptyL, false_and, or_false] at h
             rcases h with ⟨_, _, h⟩
             rcases h with ⟨_,h⟩
             rw [List.forall_iff_forall_mem] at h
-            simp at h
+            simp only [List.mem_attach, forall_const, Subtype.forall] at h
             specialize h t t_mem
             apply h
 
         · rw [List.isEmpty_iff] at emptyL
-          simp [emptyL]
+          simp only [reduceCtorEq, emptyL, false_and, or_false, false_iff, not_exists, not_and,
+            forall_exists_index]
           rename_i checkRuleMatchResult
           have checkRuleMatch': ¬ checkRuleMatch kb.prog.toSymbolSequenceMap { head := a, body := List.map Tree.root l } = Except.ok () := by
             rw [checkRuleMatchResult]
             simp
           rw [checkRuleMatchOkIffExistsRule] at checkRuleMatch'
-          simp at checkRuleMatch'
+          simp only [exists_and_left, not_exists, not_and, ne_eq] at checkRuleMatch'
           intro r rP g ground
           specialize checkRuleMatch' r rP g
           contradiction
@@ -282,7 +284,7 @@ namespace ProofTreeSkeleton
     let m := kb.prog.toSymbolSequenceMap
     l.mapExceptUnit (fun t => t.checkValidity m kb.db)
 
-  lemma checkValidityOfListOkIffAllValid [Inhabited τ.constants] (l: List (ProofTreeSkeleton τ)) (kb: KnowledgeBase τ) : checkValidityOfList l kb = Except.ok () ↔ ∀ t, t ∈ l -> t.isValid kb := by
+  lemma checkValidityOfListOkIffAllValid [Inhabited τ.constants] {l: List (ProofTreeSkeleton τ)} {kb: KnowledgeBase τ} : checkValidityOfList l kb = Except.ok () ↔ ∀ t, t ∈ l -> t.isValid kb := by
     unfold checkValidityOfList
     rw [List.mapExceptUnit_iff]
     constructor
@@ -293,11 +295,11 @@ namespace ProofTreeSkeleton
       rw [checkValidityOkIffIsValid]
       apply h t t_l
 
-  lemma checkValidityOfImplSubsetSemantics [Inhabited τ.constants] (l: List (ProofTreeSkeleton τ)) (kb: KnowledgeBase τ) : checkValidityOfList l kb = Except.ok () -> {ga | ∃ t, t ∈ l ∧ t.elem ga } ⊆ kb.proofTheoreticSemantics := by
+  lemma checkValidityOfImplSubsetSemantics [Inhabited τ.constants] {l: List (ProofTreeSkeleton τ)} {kb: KnowledgeBase τ} : checkValidityOfList l kb = Except.ok () -> {ga | ∃ t, t ∈ l ∧ t.elem ga } ⊆ kb.proofTheoreticSemantics := by
     intro h
     rw [Set.subset_def]
     intro ga
-    simp
+    simp only [Set.mem_setOf_eq, forall_exists_index, and_imp]
     intros t t_l ga_t
     rw [checkValidityOfListOkIffAllValid] at h
     apply kb.elementsOfEveryProofTreeInSemantics ⟨t, by apply h; exact t_l⟩

--- a/CertifyingDatalog/Unification.lean
+++ b/CertifyingDatalog/Unification.lean
@@ -1,43 +1,41 @@
 import CertifyingDatalog.Datalog
 
 section TermMatching
-  variable {τ: Signature} [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
+  variable {τ: Signature}
 
   namespace Substitution
-    def extend (s: Substitution τ) (v: τ.vars) (c: τ.constants) : Substitution τ := fun x => if x = v then Option.some c else s x
+    def extend [DecidableEq τ.vars] (s: Substitution τ) (v: τ.vars) (c: τ.constants) : Substitution τ := fun x => if x = v then Option.some c else s x
 
-    omit [DecidableEq τ.constants] [DecidableEq τ.relationSymbols] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols] in
-    lemma extend_subset (s: Substitution τ) (v: τ.vars) (c: τ.constants) (p: Option.isNone (s v)): s ⊆ extend s v c := by
+    lemma extend_subset [DecidableEq τ.vars] {s: Substitution τ} {v: τ.vars} {c: τ.constants} (p: Option.isNone (s v)): s ⊆ extend s v c := by
       unfold extend
       unfold_projs
       unfold subset
       intro v'
-      simp
+      simp only
       intro h
       by_cases v'_v: v' = v
-      simp [v'_v]
-      unfold domain at h
-      simp at h
-      rw [v'_v] at h
-      exfalso
-      cases h':(s v) with
-      | none =>
-        rw [h'] at h
-        simp at h
-      | some c' =>
-        rw [h'] at p
-        simp at p
+      · simp only [v'_v, ↓reduceIte]
+        unfold domain at h
+        simp only [Set.mem_setOf_eq] at h
+        rw [v'_v] at h
+        exfalso
+        cases h':(s v) with
+        | none =>
+          rw [h'] at h
+          simp at h
+        | some c' =>
+          rw [h'] at p
+          simp at p
+      · simp [v'_v]
 
-      simp [v'_v]
-
-    def matchTerm (s: Substitution τ) (t: Term τ) (c: τ.constants) : Option (Substitution τ) :=
+    def matchTerm [DecidableEq τ.vars] [DecidableEq τ.constants] (s: Substitution τ) (t: Term τ) (c: τ.constants) : Option (Substitution τ) :=
       match t with
       | .constant c' => if c = c' then Option.some s else Option.none
       | .variableDL v => match s v with
         | .some c' => if c = c' then Option.some s else Option.none
         | .none => s.extend v c
 
-    lemma matchTermSubset (s: Substitution τ) (t: Term τ) (c: τ.constants) (h : (s.matchTerm t c).isSome) : s ⊆ ((s.matchTerm t c).get h) := by
+    lemma matchTermSubset [DecidableEq τ.vars] [DecidableEq τ.constants] {s: Substitution τ} {t: Term τ} {c: τ.constants} (h : (s.matchTerm t c).isSome) : s ⊆ ((s.matchTerm t c).get h) := by
       unfold matchTerm
       cases t with
       | constant c' =>
@@ -53,14 +51,14 @@ section TermMatching
           simp [eq]
           apply Substitution.subset_refl
 
-    lemma matchTermYieldsSubs (s: Substitution τ) (t: Term τ) (c: τ.constants) (h : (s.matchTerm t c).isSome) : ((s.matchTerm t c).get h).applyTerm t = c := by
+    lemma matchTermYieldsSubs [DecidableEq τ.vars] [DecidableEq τ.constants] {s: Substitution τ} {t: Term τ} {c: τ.constants} (h : (s.matchTerm t c).isSome) : ((s.matchTerm t c).get h).applyTerm t = c := by
       unfold matchTerm
       cases t with
       | constant c' =>
-        simp
+        simp only [Option.get_ite]
         cases Decidable.em (c = c') with
         | inl eq =>
-          simp [eq]
+          simp only [eq]
           unfold applyTerm
           simp
         | inr neq =>
@@ -69,68 +67,68 @@ section TermMatching
       | variableDL v =>
         cases eq : (s v) with
         | none =>
-          simp [eq]
+          simp only [eq, Option.get_some]
           unfold applyTerm
           unfold extend
           simp
         | some c' =>
-          simp [eq]
+          simp only [eq, Option.get_ite]
           cases Decidable.em (c = c') with
           | inl eq2 =>
-            simp [eq2]
+            simp only [eq2]
             unfold applyTerm
             simp [eq]
           | inr neq =>
             unfold matchTerm at h
             simp [eq, neq] at h
 
-    lemma matchTermIsMinimal (s: Substitution τ) (t: Term τ) (c: τ.constants) (h : (s.matchTerm t c).isSome) : ∀ s' : Substitution τ, s ⊆ s' ∧ s'.applyTerm t = c -> ((s.matchTerm t c).get h) ⊆ s' := by
+    lemma matchTermIsMinimal [DecidableEq τ.vars] [DecidableEq τ.constants] {s: Substitution τ} {t: Term τ} {c: τ.constants} (h : (s.matchTerm t c).isSome) : ∀ s' : Substitution τ, s ⊆ s' ∧ s'.applyTerm t = c -> ((s.matchTerm t c).get h) ⊆ s' := by
       intro s' ⟨subset, apply_t⟩
       unfold matchTerm
       cases t with
       | constant c' =>
-        simp
+        simp only [Option.get_ite]
         apply subset
       | variableDL v =>
         cases eq2 : (s v) with
         | some c' =>
-          simp [eq2]
+          simp only [eq2, Option.get_ite]
           apply subset
         | none =>
-          simp [eq2]
+          simp only [eq2, Option.get_some]
           unfold extend
           unfold_projs
           unfold Substitution.subset
           intro v' v'_dom
           by_cases h': (v' = v)
-          · simp [h']
+          · simp only [h', ↓reduceIte]
             unfold applyTerm at apply_t
-            simp at apply_t
+            simp only at apply_t
             cases eq3 : s' v with
             | none => simp [eq3] at apply_t
             | some c' => simp [eq3] at apply_t; rw [apply_t]
-          · simp [h']
+          · simp only [h', ↓reduceIte]
             apply subset
             unfold domain at v'_dom
-            simp [h'] at v'_dom
+            simp only [Set.mem_setOf_eq, h', ↓reduceIte] at v'_dom
             unfold domain
-            simp [h']
+            simp only [Set.mem_setOf_eq]
             exact v'_dom
 
-    lemma matchTermNoneThenNoSubs (s: Substitution τ) (t: Term τ) (c: τ.constants) (h : (s.matchTerm t c).isNone) : ∀ s' : Substitution τ, s ⊆ s' -> s'.applyTerm t ≠ c := by
+    lemma matchTermNoneThenNoSubs [DecidableEq τ.vars] [DecidableEq τ.constants] {s: Substitution τ} {t: Term τ}{c: τ.constants} (h : (s.matchTerm t c) = none) : ∀ s' : Substitution τ, s ⊆ s' -> s'.applyTerm t ≠ c := by
       intro s' subset apply_t
       unfold matchTerm at h
       cases t with
       | constant c' =>
         unfold applyTerm at apply_t
-        simp at apply_t
+        simp only [Term.constant.injEq] at apply_t
         simp [apply_t] at h
       | variableDL v =>
-        simp at h
+        simp only [Option.isNone_iff_eq_none] at h
         cases eq : (s v) with
         | none => simp [eq] at h
         | some c' =>
-          simp [eq] at h
+          simp only [eq, ite_eq_right_iff, reduceCtorEq, imp_false] at h
           have : s.applyTerm (Term.variableDL v) = Term.constant c' := by unfold applyTerm; simp [eq]
           rw [subset_applyTerm_eq subset this] at apply_t
           injection apply_t with apply_t
@@ -139,7 +137,7 @@ section TermMatching
 end TermMatching
 
 section AtomMatching
-  variable {τ: Signature} [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
+  variable {τ: Signature} [DecidableEq τ.constants] [DecidableEq τ.vars]
 
   namespace Substitution
     def matchTermList (s: Substitution τ) : List ((Term τ) × τ.constants) -> Option (Substitution τ)
@@ -148,7 +146,7 @@ section AtomMatching
       | .none => Option.none
       | .some s' => s'.matchTermList l
 
-    lemma matchTermListSubset (s : Substitution τ) (l : List ((Term τ) × τ.constants)) (h : (s.matchTermList l).isSome) : s ⊆ (s.matchTermList l).get h := by
+    lemma matchTermListSubset {s : Substitution τ} {l : List ((Term τ) × τ.constants)} (h : (s.matchTermList l).isSome) : s ⊆ (s.matchTermList l).get h := by
       induction l generalizing s with
       | nil => unfold matchTermList; apply subset_refl
       | cons pair l ih =>
@@ -161,11 +159,11 @@ section AtomMatching
             simp [eq]
           simp_rw [this]
           apply subset_trans
-          apply matchTermSubset
-          apply matchPairSome
-          apply ih
+          · apply matchTermSubset
+            apply matchPairSome
+          · apply ih
 
-    lemma matchTermListYieldsSubs (s: Substitution τ) (l: List ((Term τ) × τ.constants)) (h : (s.matchTermList l).isSome) : (l.map Prod.fst).map ((s.matchTermList l).get h).applyTerm = l.map Prod.snd := by
+    lemma matchTermListYieldsSubs {s: Substitution τ} {l: List ((Term τ) × τ.constants)} (h : (s.matchTermList l).isSome) : (l.map Prod.fst).map ((s.matchTermList l).get h).applyTerm = l.map Prod.snd := by
       induction l generalizing s with
       | nil => simp
       | cons pair l ih =>
@@ -173,7 +171,7 @@ section AtomMatching
         | none => unfold matchTermList at h; simp [eq] at h
         | some s' =>
           have : (s.matchTerm pair.fst pair.snd).isSome := by simp [eq]
-          have matchTermResult := s.matchTermYieldsSubs pair.fst pair.snd this
+          have matchTermResult := s.matchTermYieldsSubs this
           have : s.matchTermList (pair::l) = ((s.matchTerm pair.fst pair.snd).get this).matchTermList l := by
             conv => left; unfold matchTermList
             simp [eq]
@@ -187,60 +185,61 @@ section AtomMatching
               simp_rw [this]
               apply matchTermListSubset
           · simp_rw [this]
-            simp [List.map_map] at ih
+            simp only [List.map_map, List.pure_def, List.bind_eq_flatMap] at ih
             apply ih
 
-    lemma matchTermListIsMinimal (s: Substitution τ) (l: List ((Term τ) × τ.constants)) (h : (s.matchTermList l).isSome) : ∀ s' : Substitution τ, s ⊆ s' ∧ ((l.map Prod.fst).map s'.applyTerm = l.map Prod.snd) -> ((s.matchTermList l).get h) ⊆ s' := by
+    lemma matchTermListIsMinimal {s: Substitution τ} {l: List ((Term τ) × τ.constants)} (h : (s.matchTermList l).isSome) : ∀ s' : Substitution τ, s ⊆ s' ∧ ((l.map Prod.fst).map s'.applyTerm = l.map Prod.snd) -> ((s.matchTermList l).get h) ⊆ s' := by
       induction l generalizing s with
       | nil => intro s ⟨subset, _⟩; simp [matchTermList]; exact subset
       | cons pair l ih =>
         intro s' ⟨subset, apply_t⟩
         rw [List.map_map] at apply_t
         unfold List.map at apply_t
-        simp at apply_t
+        simp only [Function.comp_apply, List.pure_def, List.bind_eq_flatMap, List.flatMap_cons,
+          List.singleton_append, List.cons.injEq] at apply_t
         cases eq : s.matchTerm pair.fst pair.snd with
         | none => simp [matchTermList, eq] at h
         | some s'' =>
-          simp [matchTermList, eq]
-          simp [matchTermList, eq] at h
-          simp [List.map_map] at ih
-          apply ih s'' h s' _ apply_t.right
+          simp only [matchTermList, eq]
+          simp only [matchTermList, eq] at h
+          simp only [List.map_map, List.pure_def, List.bind_eq_flatMap, and_imp] at ih
+          apply ih h s' _ apply_t.right
 
           have isSome : (s.matchTerm pair.fst pair.snd).isSome := by simp [eq]
           have : s'' = (s.matchTerm pair.fst pair.snd).get isSome := by simp [eq]
           rw [this]
           apply matchTermIsMinimal
           constructor
-          apply subset
-          apply apply_t.left
+          · apply subset
+          · apply apply_t.left
 
-    lemma matchTermListNoneThenNoSubs (s: Substitution τ) (l: List ((Term τ) × τ.constants)) (h : (s.matchTermList l).isNone) : ∀ s' : Substitution τ, s ⊆ s' -> ¬ (l.map Prod.fst).map s'.applyTerm = l.map Prod.snd := by
+    lemma matchTermListNoneThenNoSubs {s: Substitution τ} {l: List ((Term τ) × τ.constants)} (h : (s.matchTermList l) = none) : ∀ s' : Substitution τ, s ⊆ s' -> ¬ (l.map Prod.fst).map s'.applyTerm = l.map Prod.snd := by
       induction l generalizing s with
       | nil => simp [matchTermList] at h
       | cons pair l ih =>
         intro s' subset apply_t
         rw [List.map_map] at apply_t
         unfold List.map at apply_t
-        simp at apply_t
-
+        simp only [Function.comp_apply, List.pure_def, List.bind_eq_flatMap, List.flatMap_cons,
+          List.singleton_append, List.cons.injEq] at apply_t
         cases eq : s.matchTerm pair.fst pair.snd with
         | none =>
-          apply matchTermNoneThenNoSubs s pair.fst pair.snd
-          rw [eq]; simp
-          apply subset
+          apply matchTermNoneThenNoSubs eq s' subset
           apply apply_t.left
         | some s'' =>
-          simp [matchTermList, eq] at h
-          simp [List.map_map] at ih
-          apply ih s'' h s' _ apply_t.right
+          simp only [matchTermList, eq] at h
+          simp only [List.map_map, List.pure_def, List.bind_eq_flatMap] at ih
+          apply ih h s' _ apply_t.right
 
           have isSome : (s.matchTerm pair.fst pair.snd).isSome := by simp [eq]
           have : s'' = (s.matchTerm pair.fst pair.snd).get isSome := by simp [eq]
           rw [this]
           apply matchTermIsMinimal
           constructor
-          apply subset
-          apply apply_t.left
+          · apply subset
+          · apply apply_t.left
+
+    variable [DecidableEq τ.relationSymbols]
 
     def matchAtom (s: Substitution τ) (a: Atom τ) (ga: GroundAtom τ): Option (Substitution τ) :=
       if a.symbol = ga.symbol
@@ -248,17 +247,17 @@ section AtomMatching
       then s.matchTermList (a.atom_terms.zip ga.atom_terms)
       else none
 
-    lemma matchAtomSubset (s: Substitution τ) (a: Atom τ) (ga: GroundAtom τ) (h : (s.matchAtom a ga).isSome) : s ⊆ ((s.matchAtom a ga).get h) := by
+    lemma matchAtomSubset {s: Substitution τ} {a: Atom τ} {ga: GroundAtom τ} (h : (s.matchAtom a ga).isSome) : s ⊆ ((s.matchAtom a ga).get h) := by
       have symb_eq : a.symbol = ga.symbol := by
         apply Decidable.by_contra
         intro contra
         unfold matchAtom at h
         simp [contra] at h
       unfold matchAtom
-      simp [symb_eq]
+      simp only [symb_eq, ↓reduceIte]
       apply s.matchTermListSubset
 
-    lemma matchAtomYieldsSubs (s: Substitution τ) (a: Atom τ) (ga: GroundAtom τ) (h : (s.matchAtom a ga).isSome) : ((s.matchAtom a ga).get h).applyAtom a = ga := by
+    lemma matchAtomYieldsSubs {s: Substitution τ} {a: Atom τ} {ga: GroundAtom τ} (h : (s.matchAtom a ga).isSome) : ((s.matchAtom a ga).get h).applyAtom a = ga := by
       have symb_eq : a.symbol = ga.symbol := by
         apply Decidable.by_contra
         intro contra
@@ -266,54 +265,54 @@ section AtomMatching
         simp [contra] at h
       have term_lists_eq_len : a.atom_terms.length = ga.atom_terms.length := by rw [a.term_length, ga.term_length, symb_eq]
       unfold matchAtom
-      simp [symb_eq]
+      simp only [symb_eq, ↓reduceIte]
       unfold applyAtom
       unfold GroundAtom.toAtom
-      simp
+      simp only [Atom.mk.injEq]
       constructor
-      exact symb_eq
-      unfold matchAtom at h
-      simp [symb_eq] at h
-      let term_list : List ((Term τ) × τ.constants) := a.atom_terms.zip ga.atom_terms
-      have match_t_list := s.matchTermListYieldsSubs term_list h
-      have fst : a.atom_terms = term_list.map Prod.fst := by
-        rw [List.map_fst_zip]
-        apply Nat.le_of_eq
-        rw [term_lists_eq_len]
-      have snd : ga.atom_terms = term_list.map Prod.snd := by
-        rw [List.map_snd_zip]
-        apply Nat.le_of_eq
-        rw [term_lists_eq_len]
-      rw [← fst, ← snd] at match_t_list
-      rw [match_t_list]
-      simp [List.map_eq_flatMap]
+      · exact symb_eq
+      · unfold matchAtom at h
+        simp only [symb_eq, ↓reduceIte] at h
+        let term_list : List ((Term τ) × τ.constants) := a.atom_terms.zip ga.atom_terms
+        have match_t_list := s.matchTermListYieldsSubs h
+        have fst : a.atom_terms = term_list.map Prod.fst := by
+          rw [List.map_fst_zip]
+          apply Nat.le_of_eq
+          rw [term_lists_eq_len]
+        have snd : ga.atom_terms = term_list.map Prod.snd := by
+          rw [List.map_snd_zip]
+          apply Nat.le_of_eq
+          rw [term_lists_eq_len]
+        rw [← fst, ← snd] at match_t_list
+        rw [match_t_list]
+        simp [List.map_eq_flatMap]
 
-    lemma matchAtomIsMinimal (s: Substitution τ) (a: Atom τ) (ga: GroundAtom τ) (h : (s.matchAtom a ga).isSome) : ∀ s' : Substitution τ, s ⊆ s' ∧ s'.applyAtom a = ga -> ((s.matchAtom a ga).get h) ⊆ s' := by
+    lemma matchAtomIsMinimal {s: Substitution τ} {a: Atom τ} {ga: GroundAtom τ} (h : (s.matchAtom a ga).isSome) : ∀ s' : Substitution τ, s ⊆ s' ∧ s'.applyAtom a = ga -> ((s.matchAtom a ga).get h) ⊆ s' := by
       intro s' ⟨subset, apply_a⟩
       unfold applyAtom at apply_a
       unfold GroundAtom.toAtom at apply_a
-      simp at apply_a
+      simp only [Atom.mk.injEq] at apply_a
       have ⟨symb_eq, terms_eq⟩ := apply_a
       have term_lists_eq_len : a.atom_terms.length = ga.atom_terms.length := by rw [a.term_length, ga.term_length, symb_eq]
       let term_list : List ((Term τ) × τ.constants) := a.atom_terms.zip ga.atom_terms
       unfold matchAtom
-      simp [symb_eq]
-      apply s.matchTermListIsMinimal term_list
+      simp only [symb_eq, ↓reduceIte]
+      apply s.matchTermListIsMinimal
       constructor
-      apply subset
-      have fst : a.atom_terms = term_list.map Prod.fst := by
-        rw [List.map_fst_zip]
-        apply Nat.le_of_eq
-        rw [term_lists_eq_len]
-      have snd : ga.atom_terms = term_list.map Prod.snd := by
-        rw [List.map_snd_zip]
-        apply Nat.le_of_eq
-        rw [term_lists_eq_len]
-      rw [← fst, ← snd]
-      rw [terms_eq]
-      simp [List.map_eq_flatMap]
+      · apply subset
+      · have fst : a.atom_terms = term_list.map Prod.fst := by
+          rw [List.map_fst_zip]
+          apply Nat.le_of_eq
+          rw [term_lists_eq_len]
+        have snd : ga.atom_terms = term_list.map Prod.snd := by
+          rw [List.map_snd_zip]
+          apply Nat.le_of_eq
+          rw [term_lists_eq_len]
+        rw [← fst, ← snd]
+        rw [terms_eq]
+        simp [List.map_eq_flatMap]
 
-    lemma matchAtomNoneThenNoSubs (s: Substitution τ) (a: Atom τ) (ga: GroundAtom τ) (h : (s.matchAtom a ga).isNone) : ∀ s' : Substitution τ, s ⊆ s' -> s'.applyAtom a ≠ ga := by
+    lemma matchAtomNoneThenNoSubs {s: Substitution τ} {a: Atom τ} {ga: GroundAtom τ} (h : (s.matchAtom a ga) = none) : ∀ s' : Substitution τ, s ⊆ s' -> s'.applyAtom a ≠ ga := by
       intro s' subset apply_a
       unfold matchAtom at h
       unfold applyAtom at apply_a
@@ -323,10 +322,7 @@ section AtomMatching
       have term_lists_eq_len : a.atom_terms.length = ga.atom_terms.length := by rw [a.term_length, ga.term_length, symb_eq]
       simp [symb_eq] at h
       let term_list : List ((Term τ) × τ.constants) := a.atom_terms.zip ga.atom_terms
-      apply s.matchTermListNoneThenNoSubs term_list
-      simp
-      apply h
-      apply subset
+      apply s.matchTermListNoneThenNoSubs h s' subset
       have fst : a.atom_terms = term_list.map Prod.fst := by
         rw [List.map_fst_zip]
         apply Nat.le_of_eq
@@ -342,7 +338,7 @@ section AtomMatching
 end AtomMatching
 
 section RuleMatching
-  variable {τ: Signature} [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols] [Hashable τ.constants] [Hashable τ.vars] [Hashable τ.relationSymbols]
+  variable {τ: Signature} [DecidableEq τ.constants] [DecidableEq τ.vars] [DecidableEq τ.relationSymbols]
 
   namespace Substitution
     def matchAtomList (s: Substitution τ) : List ((Atom τ) × (GroundAtom τ)) -> Option (Substitution τ)
@@ -351,7 +347,7 @@ section RuleMatching
       | .none => Option.none
       | .some s' => s'.matchAtomList l
 
-    lemma matchAtomListSubset (s : Substitution τ) (l : List ((Atom τ) × (GroundAtom τ))) (h : (s.matchAtomList l).isSome) : s ⊆ (s.matchAtomList l).get h := by
+    lemma matchAtomListSubset {s : Substitution τ} {l : List ((Atom τ) × (GroundAtom τ))} (h : (s.matchAtomList l).isSome) : s ⊆ (s.matchAtomList l).get h := by
       induction l generalizing s with
       | nil => unfold matchAtomList; apply subset_refl
       | cons pair l ih =>
@@ -364,11 +360,11 @@ section RuleMatching
             simp [eq]
           simp_rw [this]
           apply subset_trans
-          apply matchAtomSubset
-          apply matchPairSome
-          apply ih
+          · apply matchAtomSubset
+            apply matchPairSome
+          · apply ih
 
-    lemma matchAtomListYieldsSubs (s: Substitution τ) (l: List ((Atom τ) × (GroundAtom τ))) (h : (s.matchAtomList l).isSome) : (l.map Prod.fst).map ((s.matchAtomList l).get h).applyAtom = l.map Prod.snd := by
+    lemma matchAtomListYieldsSubs {s: Substitution τ} {l: List ((Atom τ) × (GroundAtom τ))} (h : (s.matchAtomList l).isSome) : (l.map Prod.fst).map ((s.matchAtomList l).get h).applyAtom = l.map Prod.snd := by
       induction l generalizing s with
       | nil => simp
       | cons pair l ih =>
@@ -376,11 +372,12 @@ section RuleMatching
         | none => unfold matchAtomList at h; simp [eq] at h
         | some s' =>
           have : (s.matchAtom pair.fst pair.snd).isSome := by simp [eq]
-          have matchAtomResult := s.matchAtomYieldsSubs pair.fst pair.snd this
+          have matchAtomResult := s.matchAtomYieldsSubs this
           have : s.matchAtomList (pair::l) = ((s.matchAtom pair.fst pair.snd).get this).matchAtomList l := by
             conv => left; unfold matchAtomList
             simp [eq]
-          simp
+          simp only [List.map_cons, List.map_map, List.pure_def, List.bind_eq_flatMap,
+            List.flatMap_cons, List.singleton_append, List.cons.injEq]
           constructor
           · unfold matchAtomList at h
             cases eq : s.matchAtom pair.fst pair.snd with
@@ -390,68 +387,68 @@ section RuleMatching
               simp_rw [this]
               apply matchAtomListSubset
           · simp_rw [this]
-            simp [List.map_map] at ih
+            simp only [List.map_map, List.pure_def, List.bind_eq_flatMap] at ih
             apply ih
 
-    lemma matchAtomListNoneThenNoSubs (s: Substitution τ) (l: List ((Atom τ) × (GroundAtom τ))) (h : (s.matchAtomList l).isNone) : ∀ s' : Substitution τ, s ⊆ s' -> ¬ (l.map Prod.fst).map s'.applyAtom = l.map Prod.snd := by
+    lemma matchAtomListNoneThenNoSubs {s: Substitution τ} {l: List ((Atom τ) × (GroundAtom τ))} (h : (s.matchAtomList l) = none) : ∀ s' : Substitution τ, s ⊆ s' -> ¬ (l.map Prod.fst).map s'.applyAtom = l.map Prod.snd := by
       induction l generalizing s with
       | nil => simp [matchAtomList] at h
       | cons pair l ih =>
         intro s' subset apply_t
         rw [List.map_map] at apply_t
         unfold List.map at apply_t
-        simp at apply_t
+        simp only [Function.comp_apply, List.pure_def, List.bind_eq_flatMap, List.flatMap_cons,
+          List.singleton_append, List.cons.injEq] at apply_t
 
         cases eq : s.matchAtom pair.fst pair.snd with
         | none =>
-          apply matchAtomNoneThenNoSubs s pair.fst pair.snd
-          rw [eq]; simp
+          apply matchAtomNoneThenNoSubs eq
           apply subset
           apply apply_t.left
         | some s'' =>
           simp [matchAtomList, eq] at h
           simp [List.map_map] at ih
-          apply ih s'' h s' _ apply_t.right
+          apply ih h s' _ apply_t.right
 
           have isSome : (s.matchAtom pair.fst pair.snd).isSome := by simp [eq]
           have : s'' = (s.matchAtom pair.fst pair.snd).get isSome := by simp [eq]
           rw [this]
           apply matchAtomIsMinimal
           constructor
-          apply subset
-          apply apply_t.left
+          · apply subset
+          · apply apply_t.left
 
     def matchRule (r: Rule τ) (gr: GroundRule τ): Option (Substitution τ):=
       match empty.matchAtom r.head gr.head with
       | .none => Option.none
       | .some s => if r.body.length = gr.body.length then s.matchAtomList (r.body.zip gr.body) else Option.none
 
-    theorem matchRuleYieldsSubs (r : Rule τ) (gr : GroundRule τ) (h : (matchRule r gr).isSome) : ((matchRule r gr).get h).applyRule r = gr := by
+    theorem matchRuleYieldsSubs {r : Rule τ} {gr : GroundRule τ} (h : (matchRule r gr).isSome) : ((matchRule r gr).get h).applyRule r = gr := by
       cases eq : empty.matchAtom r.head gr.head with
       | none => simp [matchRule, eq] at h
       | some s =>
         have body_eq_len : r.body.length = gr.body.length := by
           unfold matchRule at h
-          simp [eq] at h
+          simp only [eq] at h
           apply Decidable.by_contra
           intro contra
           simp [contra] at h
         unfold applyRule
         unfold GroundRule.toRule
-        simp
+        simp only [Rule.mk.injEq]
         constructor
         · apply s.subset_applyAtom_eq
           · unfold matchRule
-            simp [eq, body_eq_len]
+            simp only [eq, body_eq_len, ↓reduceIte]
             apply matchAtomListSubset
           · have : (empty.matchAtom r.head gr.head).isSome := by simp [eq]
             have : s = (empty.matchAtom r.head gr.head).get this := by simp [eq]
             rw [this]
             apply matchAtomYieldsSubs
-        · simp [matchRule, eq, body_eq_len]
-          simp [matchRule, eq, body_eq_len] at h
+        · simp only [matchRule, eq, body_eq_len, ↓reduceIte]
+          simp only [matchRule, eq, body_eq_len, ↓reduceIte] at h
           let atom_list := r.body.zip gr.body
-          have match_a_list := s.matchAtomListYieldsSubs atom_list h
+          have match_a_list := s.matchAtomListYieldsSubs h
           have fst : r.body = atom_list.map Prod.fst := by
             rw [List.map_fst_zip]
             apply Nat.le_of_eq
@@ -464,17 +461,16 @@ section RuleMatching
           rw [match_a_list]
           simp [List.map_eq_flatMap]
 
-    theorem matchRuleNoneThenNoSubs (r : Rule τ) (gr : GroundRule τ) (h : (matchRule r gr).isNone) : ∀ s : Substitution τ, s.applyRule r ≠ gr := by
-      simp
+    theorem matchRuleNoneThenNoSubs {r : Rule τ} {gr : GroundRule τ} (h : (matchRule r gr) = none) : ∀ s : Substitution τ, s.applyRule r ≠ gr := by
+      simp only [ne_eq]
       intro s contra
       unfold applyRule at contra
       unfold GroundRule.toRule at contra
-      simp at contra
+      simp only [Rule.mk.injEq] at contra
 
       cases eq : empty.matchAtom r.head gr.head with
       | none =>
-        apply empty.matchAtomNoneThenNoSubs r.head gr.head
-        simp [eq]
+        apply empty.matchAtomNoneThenNoSubs eq
         apply empty_isMinimal
         apply contra.left
       | some s' =>
@@ -485,14 +481,14 @@ section RuleMatching
           exact this
         simp only [eq, body_eq_len] at h
         let atom_list := r.body.zip gr.body
-        apply s'.matchAtomListNoneThenNoSubs atom_list h
+        apply s'.matchAtomListNoneThenNoSubs h
         · have isSome : (empty.matchAtom r.head gr.head).isSome := by simp [eq]
           have : s' = (empty.matchAtom r.head gr.head).get isSome := by simp [eq]
           rw [this]
           apply matchAtomIsMinimal
           constructor
-          apply empty_isMinimal
-          apply contra.left
+          · apply empty_isMinimal
+          · apply contra.left
         · have fst : r.body = atom_list.map Prod.fst := by
             rw [List.map_fst_zip]
             apply Nat.le_of_eq

--- a/Main.lean
+++ b/Main.lean
@@ -32,7 +32,7 @@ section TreeListValidity
   theorem checkTreeListValidityWithUnivDatabaseUnitIffAllTreesValid (problem: TreeVerificationProblem): checkTreeListValidityWithUnivDatabase problem = Except.ok () ↔ ((∀ t ∈ problem.trees, t.isValid {prog := problem.program, db := univDatabase problem.helper.toSignature})
     ∧ ((collectModel problem.trees).toSet ⊆ {prog := problem.program, db := univDatabase problem.helper.toSignature : KnowledgeBase problem.helper.toSignature}.proofTheoreticSemantics)) := by
     unfold checkTreeListValidityWithUnivDatabase
-    simp
+    simp only
     rw [collectModelToSetIsSetOfTreesElements]
     rw [← ProofTreeSkeleton.checkValidityOfListOkIffAllValidIffAllValidAndSubsetSemantics]
 
@@ -43,7 +43,7 @@ section TreeListValidity
   theorem checkTreeListModelHoodUnitIffModel (problem: TreeVerificationProblem) (safe: problem.program.isSafe) :
     checkTreeListModelhood problem safe = Except.ok () ↔ Interpretation.models (List.toSet (collectModel problem.trees)) {prog := problem.program, db := emptyDatabase problem.helper.toSignature} := by
     unfold checkTreeListModelhood
-    simp
+    simp only
     rw [CheckableModel.checkProgramIsOkIffAllRulesAreSatisfied]
     unfold Interpretation.models
     simp
@@ -58,12 +58,13 @@ section DagValidity
   theorem checkDagValidityWithUnivDatabaseUnitIffAcyclicAndAllValid (problem: GraphVerificationProblem) : checkDagValidityWithUnivDatabase problem = Except.ok () ↔ ((problem.graph.isAcyclic ∧ (∀ a ∈ problem.graph.vertices, problem.graph.locallyValid_for_kb {prog := problem.program, db := univDatabase problem.helper.toSignature} a))
     ∧ (problem.graph.vertices.toSet ⊆ {prog := problem.program, db := univDatabase problem.helper.toSignature : KnowledgeBase problem.helper.toSignature}.proofTheoreticSemantics)) := by
     unfold checkDagValidityWithUnivDatabase
-    simp
+    simp only
     rw [problem.graph.checkValidityIsOkIffAcyclicAndAllValid {prog := problem.program, db := univDatabase problem.helper.toSignature}]
-    simp
+    simp only [iff_self_and, and_imp]
     intro acyclic all_valid
     apply Graph.verticesOfLocallyValidAcyclicGraphAreInProofTheoreticSemantics
-    exact acyclic; exact all_valid
+    · exact acyclic
+    · exact all_valid
 
   def checkDagModelhood (problem: GraphVerificationProblem) (safe: problem.program.isSafe): Except String Unit :=
     let model : CheckableModel problem.helper.toSignature := problem.graph.vertices
@@ -72,7 +73,7 @@ section DagValidity
   theorem checkDagModelhoodUnitIffModel (problem: GraphVerificationProblem) (safe: problem.program.isSafe) :
     checkDagModelhood problem safe = Except.ok () ↔ Interpretation.models (List.toSet problem.graph.vertices) {prog := problem.program, db := emptyDatabase problem.helper.toSignature} := by
     unfold checkDagModelhood
-    simp
+    simp only
     rw [CheckableModel.checkProgramIsOkIffAllRulesAreSatisfied]
     unfold Interpretation.models
     simp
@@ -87,9 +88,9 @@ section OrderedProofGraphValidity
   theorem checkOrderedGraphValidityWithUnivDatabaseUnitIffValid (problem: OrderedGraphVerificationProblem) : checkOrderedGraphValidityWithUnivDatabase problem = Except.ok () ↔ ((problem.graph.isValid {prog := problem.program, db := univDatabase problem.helper.toSignature})
     ∧ (problem.graph.labels.toSet ⊆ {prog := problem.program, db := univDatabase problem.helper.toSignature : KnowledgeBase problem.helper.toSignature}.proofTheoreticSemantics)) := by
     unfold checkOrderedGraphValidityWithUnivDatabase
-    simp
+    simp only
     rw [problem.graph.checkValidity_semantics {prog := problem.program, db := univDatabase problem.helper.toSignature}]
-    simp
+    simp only [iff_self_and]
     intro isValid
     apply OrderedProofGraph.verticesValidOrderedProofGraphAreInProofTheoreticSemantics
     exact isValid
@@ -101,7 +102,7 @@ section OrderedProofGraphValidity
   theorem checkOrderedGraphModelhoodUnitIffModel (problem: OrderedGraphVerificationProblem) (safe: problem.program.isSafe) :
     checkOrderedGraphModelhood problem safe = Except.ok () ↔ Interpretation.models (List.toSet problem.graph.labels) {prog := problem.program, db := emptyDatabase problem.helper.toSignature} := by
     unfold checkOrderedGraphModelhood
-    simp
+    simp only
     rw [CheckableModel.checkProgramIsOkIffAllRulesAreSatisfied]
     unfold Interpretation.models
     simp

--- a/Main.lean
+++ b/Main.lean
@@ -40,8 +40,8 @@ section TreeListValidity
     let model := collectModel problem.trees
     model.checkProgram problem.program safe
 
-  theorem checkTreeListModelHoodUnitIffModel (problem: TreeVerificationProblem) (safe: problem.program.isSafe) : 
-    checkTreeListModelhood problem safe = Except.ok () ↔ Interpretation.models (List.toSet (collectModel problem.trees)) {prog := problem.program, db := emptyDatabase problem.helper.toSignature} := by 
+  theorem checkTreeListModelHoodUnitIffModel (problem: TreeVerificationProblem) (safe: problem.program.isSafe) :
+    checkTreeListModelhood problem safe = Except.ok () ↔ Interpretation.models (List.toSet (collectModel problem.trees)) {prog := problem.program, db := emptyDatabase problem.helper.toSignature} := by
     unfold checkTreeListModelhood
     simp
     rw [CheckableModel.checkProgramIsOkIffAllRulesAreSatisfied]
@@ -69,8 +69,8 @@ section DagValidity
     let model : CheckableModel problem.helper.toSignature := problem.graph.vertices
     model.checkProgram problem.program safe
 
-  theorem checkDagModelhoodUnitIffModel (problem: GraphVerificationProblem) (safe: problem.program.isSafe) : 
-    checkDagModelhood problem safe = Except.ok () ↔ Interpretation.models (List.toSet problem.graph.vertices) {prog := problem.program, db := emptyDatabase problem.helper.toSignature} := by 
+  theorem checkDagModelhoodUnitIffModel (problem: GraphVerificationProblem) (safe: problem.program.isSafe) :
+    checkDagModelhood problem safe = Except.ok () ↔ Interpretation.models (List.toSet problem.graph.vertices) {prog := problem.program, db := emptyDatabase problem.helper.toSignature} := by
     unfold checkDagModelhood
     simp
     rw [CheckableModel.checkProgramIsOkIffAllRulesAreSatisfied]
@@ -98,8 +98,8 @@ section OrderedProofGraphValidity
     let model : CheckableModel problem.helper.toSignature := problem.graph.labels
     model.checkProgram problem.program safe
 
-  theorem checkOrderedGraphModelhoodUnitIffModel (problem: OrderedGraphVerificationProblem) (safe: problem.program.isSafe) : 
-    checkOrderedGraphModelhood problem safe = Except.ok () ↔ Interpretation.models (List.toSet problem.graph.labels) {prog := problem.program, db := emptyDatabase problem.helper.toSignature} := by 
+  theorem checkOrderedGraphModelhoodUnitIffModel (problem: OrderedGraphVerificationProblem) (safe: problem.program.isSafe) :
+    checkOrderedGraphModelhood problem safe = Except.ok () ↔ Interpretation.models (List.toSet problem.graph.labels) {prog := problem.program, db := emptyDatabase problem.helper.toSignature} := by
     unfold checkOrderedGraphModelhood
     simp
     rw [CheckableModel.checkProgramIsOkIffAllRulesAreSatisfied]
@@ -274,4 +274,3 @@ def main(args: List String): IO Unit := do
       | InputFormat.trees => main_trees argsParsed
       | InputFormat.graph => main_dag argsParsed
       | InputFormat.orderedGraph => main_ordered_dag argsParsed
-


### PR DESCRIPTION
This PR aims to improve the maintainability for us in case of further changes to Lean or the standard library. We do mainly 3 things:

1. We replace `simp` by `simp only [...]` whenever it is not terminal so that changes to the simp set do not affect the resulting proof state.
2. We use the focus dots now whenever there are multiple goals so that we can see clearer which goals are wrong.
3. We now derive the instances for type classes by ourselves instead of using Lean's automatic ability. This allows us to remove the typeclass from the definition and now we only use a typeclass in further lemmas when we need it. Therefore e.g. `Hashable` is only assumed, when the theorem deals with a function that actually uses a hash set/map and we have less clutter on the right side.

The changes are mainly syntactic replacements. Some proofs I have simplified by replacing our calculation by hand with `omega`, but I didn't spend much time thinking about simplifying the code base more. 
