### PR TITLE
Shortening of definitions for writeup

### DIFF
--- a/CertifyingDatalog/Basic.lean
+++ b/CertifyingDatalog/Basic.lean
@@ -30,3 +30,18 @@ namespace Nat
       simp
 end Nat
 
+namespace Option
+universe u
+
+lemma filter_true {α : Type u} {o : Option α}:
+    o.filter (fun _ => true) = o := by
+  unfold Option.filter
+  cases o <;> rfl
+
+lemma forall_ne {α : Type u} {o : Option α} :
+    (∀ (a : α), ¬ o = some a) ↔ o = none := by
+  cases o with
+  | none => simp
+  | some a' => simp
+
+end Option

--- a/CertifyingDatalog/Datalog/Substitution.lean
+++ b/CertifyingDatalog/Datalog/Substitution.lean
@@ -352,13 +352,13 @@ namespace Grounding
 
   def toSubstitution (g: Grounding τ): Substitution τ := fun t => Option.some (g t)
 
-  lemma toSubsitution_applyTerm_eq {g: Grounding τ} {t: Term τ}: g.applyTerm' t = g.toSubstitution.applyTerm t := by
+  lemma toSubstitution_applyTerm_eq {g: Grounding τ} {t: Term τ}: g.applyTerm' t = g.toSubstitution.applyTerm t := by
     unfold applyTerm'
     unfold toSubstitution
     unfold Substitution.applyTerm
     cases t <;> simp
 
-  lemma toSubsitution_applyAtom_eq {a: Atom τ} {g: Grounding τ}: g.applyAtom' a = g.toSubstitution.applyAtom a := by
+  lemma toSubstitution_applyAtom_eq {a: Atom τ} {g: Grounding τ}: g.applyAtom' a = g.toSubstitution.applyAtom a := by
     rw [Atom.ext_iff]
     unfold applyAtom'
     unfold Substitution.applyAtom
@@ -369,9 +369,9 @@ namespace Grounding
     · unfold GroundAtom.toAtom
       simp only [List.map_map, List.map_inj_left, Function.comp_apply]
       intros
-      rw [toSubsitution_applyTerm_eq]
+      rw [toSubstitution_applyTerm_eq]
 
-  lemma toSubsitution_applyRule_eq {r: Rule τ} {g: Grounding τ} : g.applyRule' r = g.toSubstitution.applyRule r := by
+  lemma toSubstitution_applyRule_eq {r: Rule τ} {g: Grounding τ} : g.applyRule' r = g.toSubstitution.applyRule r := by
     simp only
     unfold applyRule'
     unfold Substitution.applyRule
@@ -379,10 +379,10 @@ namespace Grounding
     rw [Rule.ext_iff]
     constructor
     · simp only
-      apply toSubsitution_applyAtom_eq
+      apply toSubstitution_applyAtom_eq
     · simp only [List.map_map, List.map_inj_left, Function.comp_apply]
       intros
-      rw [toSubsitution_applyAtom_eq]
+      rw [toSubstitution_applyAtom_eq]
 end Grounding
 
 theorem grounding_substitution_equiv {τ: Signature} [DecidableEq τ.vars] [Inhabited τ.constants] {r: GroundRule τ} {r': Rule τ}: (∃ (g: Grounding τ), g.applyRule' r' = r) ↔ (∃ (s: Substitution τ), s.applyRule r'= r) :=
@@ -393,7 +393,7 @@ theorem grounding_substitution_equiv {τ: Signature} [DecidableEq τ.vars] [Inha
       rcases h with ⟨g, g_prop⟩
       use g.toSubstitution
       rw [← g_prop]
-      simp [Grounding.toSubsitution_applyRule_eq]
+      simp [Grounding.toSubstitution_applyRule_eq]
     · intro h
       rcases h with ⟨s, s_prop⟩
       use s.toGrounding

--- a/CertifyingDatalog/Datastructures/Except.lean
+++ b/CertifyingDatalog/Datastructures/Except.lean
@@ -19,5 +19,9 @@ namespace Except
     unfold Except.isOk
     unfold Except.toBool
     simp
-end Except
 
+  theorem not_equal_ok_unit (e: Except A Unit): ¬ e = Except.ok () ↔ ∃ (a:A), e = Except.error a := by
+    cases e with
+    | ok u => simp
+    | error e => simp
+end Except

--- a/CertifyingDatalog/Datastructures/List.lean
+++ b/CertifyingDatalog/Datastructures/List.lean
@@ -23,6 +23,21 @@ namespace List
       | ok u => simp [eq, mapExceptUnit, ih]
       | error e => simp [eq, mapExceptUnit]
 
+  lemma mapExceptUnit_error {l: List A} {f: A → Except B Unit} {b : B}
+    (h: mapExceptUnit l f = Except.error b) : ∃ a ∈ l, f a = Except.error b := by
+  induction l with
+  | nil => simp[mapExceptUnit] at h
+  | cons hd tl ih =>
+    simp only [mapExceptUnit] at h
+    split at h
+    · rename_i h
+      simp
+      right
+      apply ih h
+    · rename_i e b h'
+      use hd
+      simp [h', h]
+
   def mapExcept.go (f: A → Except B C) (l: List A) (curr: List C): Except B (List C) :=
     match l with
     | nil => Except.ok curr

--- a/CertifyingDatalog/GraphValidation/Dfs.lean
+++ b/CertifyingDatalog/GraphValidation/Dfs.lean
@@ -293,9 +293,7 @@ section Dfs
 
     def verify_via_dfs_step (a : A) (G : Graph A) (cond : NodeCondition A) (walkFromA : {w : Walk G // w.val.head? = some a}) (verifiedNodes : HashSet A) : Except String (HashSet A) :=
       if verifiedNodes.contains a then Except.ok verifiedNodes
-      else match cond a with
-        | Except.error msg => Except.error msg
-        | Except.ok _ =>
+      else (cond a).bind (fun _ =>
           if pred_not_mem_walk : (G.predecessors a).any (fun pred => pred ∈ walkFromA.val.val)
           then Except.error "Cycle detected"
           else
@@ -308,7 +306,7 @@ section Dfs
                   pred cond walkFromPred verified
               ) (Except.ok verifiedNodes)
 
-            verifiedAfterRecursion.map (fun verified => verified.insert a)
+            verifiedAfterRecursion.map (fun verified => verified.insert a))
     termination_by Finset.card (List.toFinset G.vertices \ List.toFinset walkFromA.val.val)
 
     lemma dfs_step_result_contains_a {a : A} (G : Graph A) (cond : NodeCondition A) (walkFromA : {w : Walk G // w.val.head? = some a}) (verifiedNodes : HashSet A) (verifiedAfter : HashSet A) :
@@ -318,7 +316,8 @@ section Dfs
       simp only [List.any_eq_true, decide_eq_true_eq, dite_eq_ite] at h
       split at h
       · injection h with h; rw [← h]; assumption
-      · split at h
+      · simp only [Except.bind] at h
+        split at h
         · contradiction
         · split at h
           · contradiction
@@ -337,7 +336,8 @@ section Dfs
       simp only [List.any_eq_true, decide_eq_true_eq, dite_eq_ite] at h
       split at h
       · injection h with h; rw [h]; apply HashSet.subset_refl
-      · split at h
+      · simp only [Except.bind] at h
+        split at h
         · contradiction
         · split at h
           · contradiction
@@ -385,7 +385,8 @@ section Dfs
       simp only [List.any_eq_true, decide_eq_true_eq, dite_eq_ite] at verifiedAfterIsResult
       split at verifiedAfterIsResult
       · injection verifiedAfterIsResult with verifiedAfterIsResult; rw [← verifiedAfterIsResult]; assumption
-      · split at verifiedAfterIsResult
+      · simp only [Except.bind] at verifiedAfterIsResult
+        split at verifiedAfterIsResult
         · contradiction
         · case h_2 cond_a =>
           split at verifiedAfterIsResult
@@ -478,7 +479,8 @@ section Dfs
       simp only [List.any_eq_true, decide_eq_true_eq, dite_eq_ite, and_imp]
       split
       · simp [Except.isOk, Except.toBool]
-      · split
+      · simp only [Except.bind]
+        split
         case h_1 heq =>
           simp only [Except.isOk, Except.toBool, Bool.false_eq_true, imp_false]
           intro a_not_cycle cond_a

--- a/CertifyingDatalog/GraphValidation/Dfs.lean
+++ b/CertifyingDatalog/GraphValidation/Dfs.lean
@@ -291,7 +291,7 @@ section Dfs
               simp only [List.toFinset_cons, Finset.mem_insert, List.mem_toFinset]
               apply Or.inr; exact mem_walk_a
 
-    def verify_via_dfs_step {a : A} (G : Graph A) (cond : NodeCondition A) (walkFromA : {w : Walk G // w.val.head? = some a}) (verifiedNodes : HashSet A) : Except String (HashSet A) :=
+    def verify_via_dfs_step (a : A) (G : Graph A) (cond : NodeCondition A) (walkFromA : {w : Walk G // w.val.head? = some a}) (verifiedNodes : HashSet A) : Except String (HashSet A) :=
       if verifiedNodes.contains a then Except.ok verifiedNodes
       else match cond a with
         | Except.error msg => Except.error msg
@@ -305,16 +305,14 @@ section Dfs
                 have _termination := G.verify_via_dfs_step_termination_aux walkFromA mem (by simp at pred_not_mem_walk; apply pred_not_mem_walk; exact mem)
 
                 G.verify_via_dfs_step
-                  cond
-                  walkFromPred
-                  verified
+                  pred cond walkFromPred verified
               ) (Except.ok verifiedNodes)
 
             verifiedAfterRecursion.map (fun verified => verified.insert a)
     termination_by Finset.card (List.toFinset G.vertices \ List.toFinset walkFromA.val.val)
 
     lemma dfs_step_result_contains_a {a : A} (G : Graph A) (cond : NodeCondition A) (walkFromA : {w : Walk G // w.val.head? = some a}) (verifiedNodes : HashSet A) (verifiedAfter : HashSet A) :
-      verify_via_dfs_step G cond walkFromA verifiedNodes = Except.ok verifiedAfter -> verifiedAfter.contains a := by
+      verify_via_dfs_step a G cond walkFromA verifiedNodes = Except.ok verifiedAfter -> verifiedAfter.contains a := by
       intro h
       unfold verify_via_dfs_step at h
       simp only [List.any_eq_true, decide_eq_true_eq, dite_eq_ite] at h
@@ -333,7 +331,7 @@ section Dfs
               simp
 
     lemma dfs_step_extends_verified {a : A} (G : Graph A) (cond : NodeCondition A) (walkFromA : {w : Walk G // w.val.head? = some a}) (verifiedNodes : HashSet A) (verifiedAfter : HashSet A) :
-      verify_via_dfs_step G cond walkFromA verifiedNodes = Except.ok verifiedAfter -> verifiedNodes ⊆ verifiedAfter := by
+      verify_via_dfs_step a G cond walkFromA verifiedNodes = Except.ok verifiedAfter -> verifiedNodes ⊆ verifiedAfter := by
       intro h
       unfold verify_via_dfs_step at h
       simp only [List.any_eq_true, decide_eq_true_eq, dite_eq_ite] at h
@@ -354,7 +352,7 @@ section Dfs
                 apply HashSet.subset_trans
                 · apply List.foldl_except_is_superset_of_f_is_superset (G.predecessors a).attach (fun b pred =>
                     let walkFromPred : {w : Walk G // w.val.head? = some pred} := ⟨walkFromA.val.prependPredecessor pred (by unfold Walk.predecessors; simp [walkFromA.prop]; exact pred.prop), by (unfold Walk.prependPredecessor; simp)⟩
-                  verify_via_dfs_step G cond walkFromPred b
+                  verify_via_dfs_step pred.1 G cond walkFromPred b
                   ) verifiedNodes
                   · intro set res pred _ eq
                     have _termination := G.verify_via_dfs_step_termination_aux walkFromA pred.prop (by simp at pred_not_mem_walk; apply pred_not_mem_walk; exact pred.prop)
@@ -376,7 +374,7 @@ section Dfs
       (walkFromA : {w : Walk G // w.val.head? = some a})
       (verifiedNodes : HashSet A)
       (verifiedAfter : HashSet A)
-      (verifiedAfterIsResult : verify_via_dfs_step G cond walkFromA verifiedNodes = Except.ok verifiedAfter)
+      (verifiedAfterIsResult : verify_via_dfs_step a G cond walkFromA verifiedNodes = Except.ok verifiedAfter)
       (verifiedNodesValid : ∀ node, verifiedNodes.contains node ->
         (¬ G.reachableFromCycle node ∧
           G.cond_ok_on_all_canReach node cond)
@@ -406,7 +404,7 @@ section Dfs
               let extendWalkToA (c : A) (c_pred : c ∈ G.predecessors a) : {w : Walk G // w.val.head? = some c} := ⟨walkFromA.val.prependPredecessor c (by unfold Walk.predecessors; simp [walkFromA.prop]; exact c_pred), by (unfold Walk.prependPredecessor; simp)⟩
 
               let foldl_f : HashSet A -> {c : A // c ∈ G.predecessors a} -> Except String (HashSet A) := (fun b pred =>
-                  verify_via_dfs_step G cond (extendWalkToA pred.val pred.prop) b
+                  verify_via_dfs_step pred.1 G cond (extendWalkToA pred.val pred.prop) b
                 )
 
               have foldl_preserves := (G.predecessors a).attach.foldl_except_preserves_prop foldl_f (Except.ok verifiedNodes)
@@ -468,10 +466,10 @@ section Dfs
       (verifiedNodesValid : ∀ node, verifiedNodes.contains node ->
         (¬ G.reachableFromCycle node ∧
           G.cond_ok_on_all_canReach node cond)
-      ) : (G.verify_via_dfs_step cond walkFromA verifiedNodes).isOk ↔ (¬ G.reachableFromCycle a ∧ G.cond_ok_on_all_canReach a cond) := by
+      ) : (G.verify_via_dfs_step a cond walkFromA verifiedNodes).isOk ↔ (¬ G.reachableFromCycle a ∧ G.cond_ok_on_all_canReach a cond) := by
       constructor
       · intro check_ok
-        cases eq : G.verify_via_dfs_step cond walkFromA verifiedNodes with
+        cases eq : G.verify_via_dfs_step a cond walkFromA verifiedNodes with
         | error _ => rw [eq] at check_ok; simp [Except.isOk, Except.toBool] at check_ok
         | ok verifiedAfter =>
           apply G.dfs_step_result_valid cond walkFromA verifiedNodes verifiedAfter eq verifiedNodesValid
@@ -541,7 +539,7 @@ section Dfs
                   (G.predecessors a).attach
                   (fun b pred =>
                     let walkFromPred : {w : Walk G // w.val.head? = some pred} := ⟨walkFromA.val.prependPredecessor pred (by unfold Walk.predecessors; simp [walkFromA.prop]; exact pred.prop), by (unfold Walk.prependPredecessor; simp)⟩
-                    verify_via_dfs_step G cond walkFromPred b
+                    verify_via_dfs_step pred.1 G cond walkFromPred b
                   )
                   verifiedNodes
                   err
@@ -556,7 +554,7 @@ section Dfs
                 · simp only [List.get_eq_getElem, List.getElem_attach, pred]
                   intro cond_pred
                   let walkFromPred : {w : Walk G // w.val.head? = some pred } := ⟨walkFromA.val.prependPredecessor pred (by unfold Walk.predecessors; simp [walkFromA.prop]; simp [pred];), by (unfold Walk.prependPredecessor; simp)⟩
-                  have : (G.verify_via_dfs_step cond walkFromPred res).isOk := by
+                  have : (G.verify_via_dfs_step pred.1 cond walkFromPred res).isOk := by
                     have _termination := G.verify_via_dfs_step_termination_aux walkFromA (b := (G.predecessors a).get ⟨i, by have isLt := i.isLt; simp at isLt; exact isLt⟩) (by apply List.get_mem) (by simp at pred_not_mem_walk; apply pred_not_mem_walk; exact (by apply List.get_mem))
                     rw [dfs_step_semantics]
                     constructor
@@ -568,7 +566,7 @@ section Dfs
                       ((G.predecessors a).attach.take i)
                       (fun b pred =>
                         let walkFromPred : {w : Walk G // w.val.head? = some pred} := ⟨walkFromA.val.prependPredecessor pred (by unfold Walk.predecessors; simp [walkFromA.prop]; exact pred.prop), by (unfold Walk.prependPredecessor; simp)⟩
-                        verify_via_dfs_step G cond walkFromPred b
+                        verify_via_dfs_step pred.1 G cond walkFromPred b
                       )
                       (Except.ok verifiedNodes)
                       (fun set => ∀ node, set.contains node -> (¬ G.reachableFromCycle node ∧ G.cond_ok_on_all_canReach node cond))
@@ -601,14 +599,14 @@ section Dfs
 
     def verify_via_dfs (G : Graph A) (cond : NodeCondition A) : Except String Unit :=
       (G.vertices.attach.foldl_except
-        (fun acc ⟨a, h⟩ => G.verify_via_dfs_step (a := a) cond ⟨Walk.singleton G a h, by unfold Walk.singleton; simp⟩ acc)
+        (fun acc ⟨a, h⟩ => G.verify_via_dfs_step a cond ⟨Walk.singleton G a h, by unfold Walk.singleton; simp⟩ acc)
         (Except.ok HashSet.empty)).map (fun _ => ())
 
     lemma dfs_semantics (G : Graph A) (cond : NodeCondition A) : G.verify_via_dfs cond = Except.ok () ↔ G.isAcyclic ∧ ∀ a ∈ G.vertices, cond.true a := by
       let f :=
         (fun b (node : {a : A // a ∈ G.vertices}) =>
           let walkFromPred : {w : Walk G // w.val.head? = some node} := ⟨Walk.singleton G node node.prop, by unfold Walk.singleton; simp⟩
-          verify_via_dfs_step G cond walkFromPred b
+          verify_via_dfs_step node.1 G cond walkFromPred b
         )
 
       unfold verify_via_dfs

--- a/CertifyingDatalog/TreeValidation.lean
+++ b/CertifyingDatalog/TreeValidation.lean
@@ -157,14 +157,9 @@ namespace ProofTreeSkeleton
       then  if d.contains a
             then Except.ok ()
             else
-              match checkRuleMatch m {head:= a, body := []} with
-              | Except.ok _ => Except.ok ()
-              | Except.error msg => Except.error msg
+              (checkRuleMatch m {head:= a, body := []}).map (fun _ => ())
       else
-        match checkRuleMatch m {head:= a, body := l.map Tree.root} with
-        | Except.ok _ => l.attach.mapExceptUnit (fun ⟨t, _h⟩ => checkValidity t m d)
-        | Except.error msg => Except.error msg
-  termination_by sizeOf t
+        (checkRuleMatch m {head:= a, body := l.map Tree.root}).bind (fun _ => (l.attach.mapExceptUnit (fun ⟨t, _h⟩ => checkValidity t m d)).map (fun _ => ()))
 
   lemma checkValidityOkIffIsValid [Inhabited τ.constants] {t: ProofTreeSkeleton τ} {kb: KnowledgeBase τ} : t.checkValidity kb.prog.toSymbolSequenceMap kb.db = Except.ok () ↔ t.isValid kb :=
   by
@@ -185,87 +180,33 @@ namespace ProofTreeSkeleton
             · exact emptyL
             · exact contains_a
           · simp
-        · rw [if_neg contains_a]
+        · rw [List.isEmpty_iff] at emptyL
+          simp only [contains_a, Bool.false_eq_true, ↓reduceIte, Except.map, emptyL, List.map_nil,
+            exists_and_left, exists_and_right, and_false, or_false]
           split
-          · simp only [exists_and_left, exists_and_right, true_iff]
-            rename_i u checkRuleMatch
-            rw [checkRuleMatchOkIffExistsRule] at checkRuleMatch
-            left
-            rw [List.isEmpty_iff] at emptyL
-            rcases checkRuleMatch with ⟨r, g, rP, apply_g⟩
-            use r
-            constructor
-            · apply rP
-            · constructor
-              · use g
-                rw [emptyL]
-                simp only [List.map_nil]
-                exact apply_g
-              · rw [emptyL]
-                unfold List.Forall
-                simp
-          · simp only [reduceCtorEq, exists_and_left, exists_and_right, false_iff, not_or,
-            not_exists, not_and, forall_exists_index, Bool.not_eq_true]
+          · simp only [reduceCtorEq, false_iff, not_exists, not_and, forall_exists_index]
             rename_i checkRuleMatchResult
-            rw [List.isEmpty_iff] at emptyL
-
             have checkRuleMatch': ¬ checkRuleMatch kb.prog.toSymbolSequenceMap { head := a, body := [] } = Except.ok () := by
               rw [checkRuleMatchResult]
               simp
-            rw [checkRuleMatchOkIffExistsRule] at checkRuleMatch'
-            simp only [exists_and_left, not_exists, not_and, ne_eq] at checkRuleMatch'
-            constructor
-            · rw [emptyL]
-              simp only [List.map_nil, List.attach_nil, List.Forall, not_true_eq_false, imp_false,
-                ne_eq]
-              apply checkRuleMatch'
-            · simp [contains_a]
-
-      · simp only [emptyL, Bool.false_eq_true, ↓reduceIte, exists_and_left, exists_and_right]
-        split
-        · rename_i checkRuleMatchResult
-          rw [checkRuleMatchOkIffExistsRule] at checkRuleMatchResult
-          rcases checkRuleMatchResult with ⟨r,g,rP, rulegrounding⟩
-          rw [List.mapExceptUnit_iff]
-          constructor
-          · intro h
-            left
+            simp only [checkRuleMatchOkIffExistsRule, exists_and_left, not_exists, not_and,
+              ne_eq] at checkRuleMatch'
+            intro r r_mem g g_apply
+            simp only [List.forall_iff_forall_mem, List.mem_attach, forall_const, Subtype.forall,
+              emptyL, List.not_mem_nil, IsEmpty.forall_iff, implies_true, not_true_eq_false]
+            specialize checkRuleMatch' r r_mem g
+            contradiction
+          · rename_i u checkRuleMatch
+            rw [checkRuleMatchOkIffExistsRule] at checkRuleMatch
+            rcases checkRuleMatch with ⟨r, g, rP, apply_g⟩
+            simp only [true_iff]
             use r
-            constructor
-            · apply rP
-            · constructor
-              · use g
-              · rw [List.forall_iff_forall_mem]
-                simp only [List.mem_attach, forall_const, Subtype.forall]
-                intro t t_mem
-                specialize ih t.height
-                have height_t: t.height < n := by
-                  rw [← h_t]
-                  apply Tree.heightOfMemberIsSmaller
-                  unfold Tree.member
-                  simp [t_mem]
-                simp only [List.mem_attach, forall_const, Subtype.forall] at h
-                specialize h t t_mem
-                rw [ih height_t rfl] at h
-                exact h
-          · intro h
-            simp only [List.mem_attach, forall_const, Subtype.forall]
-            intro t t_mem
-            specialize ih t.height
-            have height_t: t.height < n := by
-              rw [← h_t]
-              apply Tree.heightOfMemberIsSmaller
-              simp [Tree.member, t_mem]
-            rw [ih height_t rfl]
-            rw [List.isEmpty_iff] at emptyL
-            simp only [emptyL, false_and, or_false] at h
-            rcases h with ⟨_, _, h⟩
-            rcases h with ⟨_,h⟩
-            rw [List.forall_iff_forall_mem] at h
-            simp only [List.mem_attach, forall_const, Subtype.forall] at h
-            specialize h t t_mem
-            apply h
+            refine And.intro rP (And.intro (by use g) ?_)
+            simp [List.forall_iff_forall_mem, emptyL]
 
+      · simp only [emptyL, Bool.false_eq_true, ↓reduceIte, Except.bind, exists_and_left,
+        exists_and_right]
+        split
         · rw [List.isEmpty_iff] at emptyL
           simp only [reduceCtorEq, emptyL, false_and, or_false, false_iff, not_exists, not_and,
             forall_exists_index]
@@ -278,7 +219,46 @@ namespace ProofTreeSkeleton
           intro r rP g ground
           specialize checkRuleMatch' r rP g
           contradiction
-
+        · rename_i checkRuleMatchResult
+          rw [List.isEmpty_iff] at emptyL
+          simp [emptyL]
+          rw [checkRuleMatchOkIffExistsRule] at checkRuleMatchResult
+          rcases checkRuleMatchResult with ⟨r,g,rP, rulegrounding⟩
+          simp [Except.map]
+          split
+          · simp
+            intro r rP g apply_g
+            rename_i e s h
+            simp [List.forall_iff_forall_mem]
+            have := List.mapExceptUnit_error h
+            simp at this
+            rcases this with ⟨t, t_mem, ht⟩
+            use t
+            have height_t: t.height < n := by
+              rw [← h_t]
+              apply Tree.heightOfMemberIsSmaller
+              simp [Tree.member, t_mem]
+            specialize ih t.height
+            simp [t_mem, ← ih height_t rfl, Except.not_equal_ok_unit]
+            use s
+          · rename_i e u h
+            rw [List.mapExceptUnit_iff] at h
+            simp
+            use r
+            refine And.intro rP (And.intro (by use g) ?_)
+            rw [List.forall_iff_forall_mem]
+            simp only [List.mem_attach, forall_const, Subtype.forall]
+            intro t t_mem
+            specialize ih t.height
+            have height_t: t.height < n := by
+              rw [← h_t]
+              apply Tree.heightOfMemberIsSmaller
+              unfold Tree.member
+              simp [t_mem]
+            simp only [List.mem_attach, forall_const, Subtype.forall] at h
+            specialize h t t_mem
+            rw [ih height_t rfl] at h
+            exact h
 
   def checkValidityOfList (l: List (ProofTreeSkeleton τ)) (kb : KnowledgeBase τ) : Except String Unit :=
     let m := kb.prog.toSymbolSequenceMap

--- a/CertifyingDatalog/TreeValidation.lean
+++ b/CertifyingDatalog/TreeValidation.lean
@@ -159,7 +159,7 @@ namespace ProofTreeSkeleton
             else
               (checkRuleMatch m {head:= a, body := []}).map (fun _ => ())
       else
-        (checkRuleMatch m {head:= a, body := l.map Tree.root}).bind (fun _ => (l.attach.mapExceptUnit (fun ⟨t, _h⟩ => checkValidity t m d)).map (fun _ => ()))
+        (checkRuleMatch m {head:= a, body := l.map Tree.root}).bind (fun _ => (l.attach.mapExceptUnit (fun ⟨t, _h⟩ => checkValidity t m d)))
 
   lemma checkValidityOkIffIsValid [Inhabited τ.constants] {t: ProofTreeSkeleton τ} {kb: KnowledgeBase τ} : t.checkValidity kb.prog.toSymbolSequenceMap kb.db = Except.ok () ↔ t.isValid kb :=
   by
@@ -206,9 +206,9 @@ namespace ProofTreeSkeleton
 
       · simp only [emptyL, Bool.false_eq_true, ↓reduceIte, Except.bind, exists_and_left,
         exists_and_right]
+        rw [List.isEmpty_iff] at emptyL
         split
-        · rw [List.isEmpty_iff] at emptyL
-          simp only [reduceCtorEq, emptyL, false_and, or_false, false_iff, not_exists, not_and,
+        · simp only [reduceCtorEq, emptyL, false_and, or_false, false_iff, not_exists, not_and,
             forall_exists_index]
           rename_i checkRuleMatchResult
           have checkRuleMatch': ¬ checkRuleMatch kb.prog.toSymbolSequenceMap { head := a, body := List.map Tree.root l } = Except.ok () := by
@@ -219,46 +219,34 @@ namespace ProofTreeSkeleton
           intro r rP g ground
           specialize checkRuleMatch' r rP g
           contradiction
-        · rename_i checkRuleMatchResult
-          rw [List.isEmpty_iff] at emptyL
-          simp [emptyL]
-          rw [checkRuleMatchOkIffExistsRule] at checkRuleMatchResult
-          rcases checkRuleMatchResult with ⟨r,g,rP, rulegrounding⟩
-          simp [Except.map]
-          split
-          · simp
-            intro r rP g apply_g
-            rename_i e s h
-            simp [List.forall_iff_forall_mem]
-            have := List.mapExceptUnit_error h
-            simp at this
-            rcases this with ⟨t, t_mem, ht⟩
-            use t
-            have height_t: t.height < n := by
-              rw [← h_t]
-              apply Tree.heightOfMemberIsSmaller
-              simp [Tree.member, t_mem]
-            specialize ih t.height
-            simp [t_mem, ← ih height_t rfl, Except.not_equal_ok_unit]
-            use s
-          · rename_i e u h
-            rw [List.mapExceptUnit_iff] at h
-            simp
+        · rename_i e u h
+          rw [checkRuleMatchOkIffExistsRule] at h
+          simp only [emptyL, false_and, or_false]
+          have height : ∀ (t: Tree (GroundAtom τ)), t ∈ l → t.height < n := by
+            simp only [← h_t]
+            intro t ht
+            apply Tree.heightOfMemberIsSmaller
+            simp only [Tree.member]
+            exact ht
+          constructor
+          · intro h'
+            rcases h with ⟨r, g, rP, hg⟩
             use r
             refine And.intro rP (And.intro (by use g) ?_)
-            rw [List.forall_iff_forall_mem]
-            simp only [List.mem_attach, forall_const, Subtype.forall]
-            intro t t_mem
-            specialize ih t.height
-            have height_t: t.height < n := by
-              rw [← h_t]
-              apply Tree.heightOfMemberIsSmaller
-              unfold Tree.member
-              simp [t_mem]
-            simp only [List.mem_attach, forall_const, Subtype.forall] at h
-            specialize h t t_mem
-            rw [ih height_t rfl] at h
-            exact h
+            simp only [List.forall_iff_forall_mem, List.mem_attach, forall_const, Subtype.forall]
+            simp only [List.mapExceptUnit_iff, List.mem_attach, forall_const, Subtype.forall] at h'
+            intro t ht
+            specialize ih t.height (height t ht) rfl
+            rw [← ih]
+            exact h' t ht
+          · intro h'
+            simp only [List.mapExceptUnit_iff, List.mem_attach, forall_const, Subtype.forall]
+            intro t ht
+            rw [ih t.height (height t ht) rfl]
+            rcases h' with ⟨_, _, _, h'⟩
+            simp only [List.forall_iff_forall_mem, List.mem_attach, forall_const,
+              Subtype.forall] at h'
+            exact h' t ht
 
   def checkValidityOfList (l: List (ProofTreeSkeleton τ)) (kb : KnowledgeBase τ) : Except String Unit :=
     let m := kb.prog.toSymbolSequenceMap

--- a/CertifyingDatalog/Unification.lean
+++ b/CertifyingDatalog/Unification.lean
@@ -419,9 +419,7 @@ section RuleMatching
           · apply apply_t.left
 
     def matchRule (r: Rule τ) (gr: GroundRule τ): Option (Substitution τ):=
-      match empty.matchAtom r.head gr.head with
-      | .none => Option.none
-      | .some s => if r.body.length = gr.body.length then s.matchAtomList (r.body.zip gr.body) else Option.none
+      ((empty.matchAtom r.head gr.head).bind fun s => s.matchAtomList (r.body.zip gr.body)).filter (fun _ => r.body.length = gr.body.length)
 
     theorem matchRuleYieldsSubs {r : Rule τ} {gr : GroundRule τ} (h : (matchRule r gr).isSome) : ((matchRule r gr).get h).applyRule r = gr := by
       cases eq : empty.matchAtom r.head gr.head with
@@ -429,24 +427,24 @@ section RuleMatching
       | some s =>
         have body_eq_len : r.body.length = gr.body.length := by
           unfold matchRule at h
-          simp only [eq] at h
-          apply Decidable.by_contra
-          intro contra
-          simp [contra] at h
+          simp only [eq, Option.some_bind, Option.isSome_iff_exists, Option.filter_eq_some,
+            Option.mem_def, decide_eq_true_eq, exists_and_right] at h
+          apply And.right h
         unfold applyRule
         unfold GroundRule.toRule
         simp only [Rule.mk.injEq]
         constructor
         · apply s.subset_applyAtom_eq
           · unfold matchRule
-            simp only [eq, body_eq_len, ↓reduceIte]
+            simp [eq, body_eq_len, ↓reduceIte, Option.filter_true]
             apply matchAtomListSubset
           · have : (empty.matchAtom r.head gr.head).isSome := by simp [eq]
             have : s = (empty.matchAtom r.head gr.head).get this := by simp [eq]
             rw [this]
             apply matchAtomYieldsSubs
-        · simp only [matchRule, eq, body_eq_len, ↓reduceIte]
-          simp only [matchRule, eq, body_eq_len, ↓reduceIte] at h
+        · simp only [matchRule, body_eq_len, decide_true, eq, Option.some_bind, Option.filter_true]
+          simp only [matchRule, body_eq_len, decide_true, eq, Option.some_bind,
+            Option.filter_true] at h
           let atom_list := r.body.zip gr.body
           have match_a_list := s.matchAtomListYieldsSubs h
           have fst : r.body = atom_list.map Prod.fst := by
@@ -479,7 +477,8 @@ section RuleMatching
           have : (r.body.map s.applyAtom).length = (gr.body.map GroundAtom.toAtom).length := by rw [contra.right]
           rw [List.length_map, List.length_map] at this
           exact this
-        simp only [eq, body_eq_len] at h
+        simp only [body_eq_len, decide_true, eq, Option.some_bind, Option.filter_eq_none,
+          Option.mem_def, not_true_eq_false, imp_false, Option.forall_ne, or_self] at h
         let atom_list := r.body.zip gr.body
         apply s'.matchAtomListNoneThenNoSubs h
         · have isSome : (empty.matchAtom r.head gr.head).isSome := by simp [eq]


### PR DESCRIPTION
This PR halves the length of the definition of `matchRule` using some Option functions to save space. Let me know if thats understandable. 