### PR TITLE
Shorter graph definitions for writeup

### DIFF
--- a/CertifyingDatalog/GraphValidation/Basic.lean
+++ b/CertifyingDatalog/GraphValidation/Basic.lean
@@ -1,27 +1,27 @@
 import CertifyingDatalog.Basic
 import CertifyingDatalog.Datalog
 
-abbrev PreGraph (A: Type u) [DecidableEq A] [Hashable A] := Std.HashMap A (List A)
+variable {A: Type u} [DecidableEq A] [Hashable A]
+
+variable (A) in abbrev PreGraph := Std.HashMap A (List A)
 
 namespace PreGraph
-  variable {A: Type u} [DecidableEq A] [Hashable A]
 
   def vertices (g : PreGraph A) : List A := g.keys
-  def predecessors (g : PreGraph A) (a : A) : List A := g.getD a []
+  def preds (g : PreGraph A) (a : A) : List A := g.getD a []
 
-  def complete (pg: PreGraph A) := ∀ (a:A), pg.contains a →  ∀ (a':A), a' ∈ (pg.predecessors a) → pg.contains a'
-
-  theorem in_vertices_iff_contains {pg: PreGraph A} {a : A} : a ∈ pg.vertices ↔ pg.contains a := by
+  def complete (g: PreGraph A) := ∀ a ∈ g, (g.preds a).all fun x => x ∈ g
+  theorem in_vertices_iff_mem {pg: PreGraph A} {a : A} : a ∈ pg.vertices ↔ a ∈ pg := by
     unfold vertices
     rw [Std.HashMap.mem_keys, Std.HashMap.mem_iff_contains]
 
-  theorem in_predecessors_iff_found {pg: PreGraph A} {a : A} : ∀ b, b ∈ pg.predecessors a ↔ b ∈ (pg.getD a []) := by
-    unfold predecessors; intros; rfl
+  theorem in_predecessors_iff_found {pg: PreGraph A} {a : A} : ∀ b, b ∈ pg.preds a ↔ b ∈ (pg.getD a []) := by
+    unfold preds; intros; rfl
 
   def from_vertices (vs : List A) : PreGraph A := Std.HashMap.ofList (vs.map (fun v => (v, [])))
 
   def add_vertex (pg : PreGraph A) (v : A) : PreGraph A :=
-    if pg.contains v then
+    if v ∈ pg then
       pg
     else
       pg.insert v []
@@ -29,7 +29,7 @@ namespace PreGraph
   def add_vertices (pg : PreGraph A) (vs : List A) : PreGraph A :=
     vs.foldl (fun (acc : PreGraph A) u => acc.add_vertex u) pg
 
-  theorem add_vertices_contains_iff_contains_or_in_list {pg : PreGraph A} {vs : List A} : ∀ v, (pg.add_vertices vs).contains v ↔ pg.contains v ∨ (¬ pg.contains v ∧ v ∈ vs) := by
+  theorem mem_add_vertices_iff_mem_or_in_list {pg : PreGraph A} {vs : List A} : ∀ v, v ∈ (pg.add_vertices vs) ↔ v ∈ pg ∨ (¬ v ∈ pg ∧ v ∈ vs) := by
     induction vs generalizing pg with
     | nil => simp [add_vertices]
     | cons u us ih =>
@@ -45,8 +45,8 @@ namespace PreGraph
           split at hl
           · apply Or.inl
             exact hl
-          · rw [Std.HashMap.contains_insert] at hl
-            cases Decidable.em (pg.contains v) with
+          · rw [Std.HashMap.mem_insert] at hl
+            cases Decidable.em (v ∈ pg) with
             | inl v_in_pg => apply Or.inl; exact v_in_pg
             | inr v_not_in_pg =>
               simp only [Bool.or_eq_true, beq_iff_eq] at hl
@@ -58,12 +58,11 @@ namespace PreGraph
           split at hr
           · apply Or.inr
             constructor
-            · simp only [Bool.not_eq_true] at hr
-              exact hr.left
+            · exact hr.left
             · apply Or.inr
               exact hr.right
-          · rw [Std.HashMap.contains_insert] at hr
-            cases Decidable.em (pg.contains v) with
+          · rw [Std.HashMap.mem_insert] at hr
+            cases Decidable.em (v ∈ pg) with
             | inl v_in_pg => apply Or.inl; exact v_in_pg
             | inr v_not_in_pg => apply Or.inr; constructor; simp at v_not_in_pg; exact v_not_in_pg; apply Or.inr; exact hr.right
       · intro h
@@ -73,8 +72,8 @@ namespace PreGraph
           unfold add_vertex
           split
           · exact hl
-          · rw [Std.HashMap.contains_insert]
-            simp only [Bool.or_eq_true, beq_iff_eq]
+          · rw [Std.HashMap.mem_insert]
+            simp only [beq_iff_eq]
             apply Or.inr
             exact hl
         | inr hr =>
@@ -86,14 +85,14 @@ namespace PreGraph
             split
             · case isTrue u_in_pg =>
               apply False.elim; rw [v_is_u] at hrl
-              have : ¬ pg.contains u := by simp [hrl]
+              have : ¬ u ∈ pg := by simp [hrl]
               contradiction
-            · rw [Std.HashMap.contains_insert]
+            · rw [Std.HashMap.mem_insert]
               simp
               apply Or.inl
               rw [v_is_u]
           | inr v_in_us =>
-            cases Decidable.em ((pg.add_vertex u).contains v)
+            cases Decidable.em (v ∈ pg.add_vertex u)
             · apply Or.inl
               assumption
             · apply Or.inr
@@ -117,16 +116,14 @@ namespace PreGraph
           simp only [beq_iff_eq, ite_eq_right_iff, List.nil_eq]
           intro eq
           apply Eq.symm
-          rw [Std.HashMap.getD_eq_fallback_of_contains_eq_false]
-          rw [← eq]
-          simp only [Bool.not_eq_true] at h
-          exact h
+          rw [Std.HashMap.getD_eq_fallback]
+          simp [← eq, h]
 
   def add_vertex_with_predecessors (pg : PreGraph A) (v : A) (vs : List A) : PreGraph A :=
-    let pg_with_added_predecessors := if pg.contains v then pg.insert v ((pg.predecessors v) ++ vs) else pg.insert v vs
+    let pg_with_added_predecessors := if v ∈ pg then pg.insert v ((pg.preds v) ++ vs) else pg.insert v vs
     PreGraph.add_vertices pg_with_added_predecessors vs
 
-  theorem from_vertices_contains_exactly_the_passed_vertices (vs : List A) : ∀ v, v ∈ (PreGraph.from_vertices vs).vertices ↔ v ∈ vs := by
+  theorem mem_from_vertices_iff_mem (vs : List A) : ∀ v, v ∈ (PreGraph.from_vertices vs).vertices ↔ v ∈ vs := by
     unfold vertices
     unfold from_vertices
     intro v
@@ -149,29 +146,25 @@ namespace PreGraph
     simp
 
   theorem from_vertices_is_complete (vs : List A) : (PreGraph.from_vertices vs).complete := by
-    let pg := PreGraph.from_vertices vs
-    have : ∀ v, pg.getD v [] = [] := by
+    have : ∀ v, (PreGraph.from_vertices vs).getD v [] = [] := by
       intro v
       apply from_vertices_no_vertex_has_predecessors
-    intro a ha b hb
-    rw [← in_vertices_iff_contains] at ha
-    unfold predecessors at hb
-    rw [this a] at hb
-    contradiction
+    intro a ha
+    simp [List.all_eq_true, decide_eq_true_eq, preds, this a]
 
-  theorem add_vertex_with_predecessors_contains_iff_contains_or_in_new_vertices (pg : PreGraph A) (v : A) (vs : List A) : ∀ a, (pg.add_vertex_with_predecessors v vs).contains a ↔ (pg.contains a ∧ a = v) ∨ (pg.contains a ∧ a ≠ v) ∨ ((¬ pg.contains a) ∧ a = v) ∨ ((¬ pg.contains a) ∧ a ≠ v ∧ a ∈ vs) := by
+  theorem mem_add_vertex_with_predecessors_iff_mem_or_in_new_vertices (pg : PreGraph A) (v : A) (vs : List A) : ∀ a, a ∈ (pg.add_vertex_with_predecessors v vs) ↔ (a ∈ pg ∧ a = v) ∨ (a ∈ pg ∧ a ≠ v) ∨ ((¬ a ∈ pg) ∧ a = v) ∨ ((¬ a ∈ pg) ∧ a ≠ v ∧ a ∈ vs) := by
     unfold add_vertex_with_predecessors
     simp only [ne_eq, Bool.not_eq_true]
     intro a
-    rw [add_vertices_contains_iff_contains_or_in_list]
+    rw [mem_add_vertices_iff_mem_or_in_list]
     constructor
     · intro h
       cases h with
       | inl hl =>
         split at hl
         case isTrue hl' =>
-          rw [Std.HashMap.contains_insert] at hl
-          simp only [Bool.or_eq_true, beq_iff_eq] at hl
+          rw [Std.HashMap.mem_insert] at hl
+          simp only [beq_iff_eq] at hl
           cases hl with
           | inl hll =>
             apply Or.inl
@@ -184,7 +177,7 @@ namespace PreGraph
             | inl a_eq_v => apply Or.inl; constructor; exact hlr; exact a_eq_v
             | inr a_neq_v => apply Or.inr; apply Or.inl; constructor; exact hlr; exact a_neq_v
         case isFalse hr' =>
-          rw [Std.HashMap.contains_insert] at hl
+          rw [Std.HashMap.mem_insert] at hl
           simp only [Bool.or_eq_true, beq_iff_eq] at hl
           cases hl with
           | inl hll =>
@@ -193,8 +186,7 @@ namespace PreGraph
             apply Or.inl
             constructor
             · rw [← hll]
-              simp only [Bool.not_eq_true] at hr'
-              apply hr'
+              exact hr'
             · rw [hll]
           | inr hlr =>
             cases Decidable.em (a = v) with
@@ -204,7 +196,7 @@ namespace PreGraph
         let ⟨hrl, hrr⟩ := hr
         split at hrl
         case isTrue hl' =>
-          rw [Std.HashMap.contains_insert] at hrl
+          rw [Std.HashMap.mem_insert] at hrl
           simp only [Bool.or_eq_true, beq_iff_eq, not_or, Bool.not_eq_true] at hrl
           cases Decidable.em (a = v) with
           | inl a_eq_v =>
@@ -212,23 +204,22 @@ namespace PreGraph
             have contra := hrl.left
             contradiction
           | inr a_neq_v =>
-            cases Decidable.em (pg.contains a) with
-            | inl pg_contains =>
-              rw [pg_contains] at hrl
+            cases Decidable.em (a ∈ pg) with
+            | inl mem =>
+              simp only [mem, true_and, not_true_eq_false, false_and, or_self, or_false]
               have contra := hrl.right
               contradiction
-            | inr pg_not_contains =>
+            | inr not_mem =>
               apply Or.inr
               apply Or.inr
               apply Or.inr
               constructor
-              simp only [Bool.not_eq_true] at pg_not_contains
-              apply pg_not_contains
+              apply not_mem
               constructor
               · apply a_neq_v
               · apply hrr
         case isFalse hr' =>
-          rw [Std.HashMap.contains_insert] at hrl
+          rw [Std.HashMap.mem_insert] at hrl
           simp only [Bool.or_eq_true, beq_iff_eq, not_or, Bool.not_eq_true] at hrl
           cases Decidable.em (a = v) with
           | inl a_eq_v =>
@@ -236,18 +227,16 @@ namespace PreGraph
             have contra := hrl.left
             contradiction
           | inr a_neq_v =>
-            cases Decidable.em (pg.contains a) with
-            | inl pg_contains =>
-              rw [pg_contains] at hrl
-              have contra := hrl.right
-              contradiction
-            | inr pg_not_contains =>
+            cases Decidable.em (a ∈ pg) with
+            | inl mem =>
+              simp only [mem, not_true_eq_false, and_false] at hrl
+            | inr not_mem =>
               apply Or.inr
               apply Or.inr
               apply Or.inr
               constructor
-              · simp only [Bool.not_eq_true] at pg_not_contains
-                apply pg_not_contains
+              · simp only at not_mem
+                apply not_mem
               · constructor
                 · apply a_neq_v
                 · apply hrr
@@ -256,11 +245,11 @@ namespace PreGraph
       | inl hll =>
         apply Or.inl
         split
-        · rw [Std.HashMap.contains_insert]
+        · rw [Std.HashMap.mem_insert]
           simp only [Bool.or_eq_true, beq_iff_eq]
           apply Or.inl
           rw [hll.right]
-        · rw [Std.HashMap.contains_insert]
+        · rw [Std.HashMap.mem_insert]
           simp only [Bool.or_eq_true, beq_iff_eq]
           apply Or.inl
           rw [hll.right]
@@ -268,31 +257,31 @@ namespace PreGraph
         | inl hll =>
           apply Or.inl
           split
-          · rw [Std.HashMap.contains_insert]
+          · rw [Std.HashMap.mem_insert]
             simp only [Bool.or_eq_true, beq_iff_eq]
             apply Or.inr
-            rw [hll.left]
-          · rw [Std.HashMap.contains_insert]
+            simp [hll.left]
+          · rw [Std.HashMap.mem_insert]
             simp only [Bool.or_eq_true, beq_iff_eq]
             apply Or.inr
-            rw [hll.left]
+            simp [hll.left]
         | inr hlr => cases hlr with
           | inl hll =>
             apply Or.inl
             split
-            · rw [Std.HashMap.contains_insert]
+            · rw [Std.HashMap.mem_insert]
               simp only [Bool.or_eq_true, beq_iff_eq]
               apply Or.inr
               rw [hll.right]
               assumption
-            · rw [Std.HashMap.contains_insert]
+            · rw [Std.HashMap.mem_insert]
               simp only [Bool.or_eq_true, beq_iff_eq]
               apply Or.inl
               rw [hll.right]
           | inr hlr =>
             apply Or.inr
             split
-            · rw [Std.HashMap.contains_insert]
+            · rw [Std.HashMap.mem_insert]
               simp
               constructor
               · constructor
@@ -303,46 +292,44 @@ namespace PreGraph
               · apply hlr.right.right
             · constructor
               · intro contra
-                rw [Std.HashMap.contains_insert] at contra
+                rw [Std.HashMap.mem_insert] at contra
                 simp only [Bool.or_eq_true, beq_iff_eq] at contra
                 cases contra with
                 | inl contra => apply hlr.right.left; rw [contra]
-                | inr contra => have contra' := hlr.left; rw [contra'] at contra; contradiction
+                | inr contra => have contra' := hlr.left; contradiction
               · apply hlr.right.right
 
-  theorem add_vertex_with_predecessors_getD_semantics_1 (pg : PreGraph A) (v a : A) (vs : List A) (h : pg.contains a ∧ a = v) : (pg.add_vertex_with_predecessors v vs).getD a [] = (pg.predecessors v) ++ vs := by
+  theorem add_vertex_with_predecessors_getD_semantics_1 (pg : PreGraph A) (v a : A) (vs : List A) (h : a ∈ pg ∧ a = v) : (pg.add_vertex_with_predecessors v vs).getD a [] = (pg.preds v) ++ vs := by
     unfold add_vertex_with_predecessors
     simp only
     rw [add_vertices_getD_semantics]
     rw [← h.right]
     simp [h.left]
 
-  theorem add_vertex_with_predecessors_getD_semantics_2 (pg : PreGraph A) (v a : A) (vs : List A) (h : pg.contains a ∧ a ≠ v) : (pg.add_vertex_with_predecessors v vs).getD a [] = (pg.predecessors a) := by
+  theorem add_vertex_with_predecessors_getD_semantics_2 (pg : PreGraph A) (v a : A) (vs : List A) (h : a ∈ pg ∧ a ≠ v) : (pg.add_vertex_with_predecessors v vs).getD a [] = (pg.preds a) := by
     unfold add_vertex_with_predecessors
     simp only
     rw [add_vertices_getD_semantics]
     split
     · rw [Std.HashMap.getD_insert]
-      simp only [beq_iff_eq]
+      simp [beq_iff_eq]
       split
       · case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
-      · unfold predecessors
-        rfl
+      · simp [preds]
     · rw [Std.HashMap.getD_insert]
       simp only [beq_iff_eq]
       split
       · case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
-      · unfold predecessors
-        rfl
+      · simp [preds]
 
-  theorem add_vertex_with_predecessors_getD_semantics_3 (pg : PreGraph A) (v a : A) (vs : List A) (h : (¬ pg.contains a) ∧ a = v) : (pg.add_vertex_with_predecessors v vs).getD a [] = vs := by
+  theorem add_vertex_with_predecessors_getD_semantics_3 (pg : PreGraph A) (v a : A) (vs : List A) (h : (¬ a ∈ pg) ∧ a = v) : (pg.add_vertex_with_predecessors v vs).getD a [] = vs := by
     unfold add_vertex_with_predecessors
     simp only
     rw [add_vertices_getD_semantics]
     rw [← h.right]
     simp [h.left]
 
-  theorem add_vertex_with_predecessors_getD_semantics_4 (pg : PreGraph A) (v a : A) (vs : List A) (h : (¬ pg.contains a) ∧ a ≠ v) : (pg.add_vertex_with_predecessors v vs).getD a [] = [] := by
+  theorem add_vertex_with_predecessors_getD_semantics_4 (pg : PreGraph A) (v a : A) (vs : List A) (h : (¬ a ∈ pg) ∧ a ≠ v) : (pg.add_vertex_with_predecessors v vs).getD a [] = [] := by
     unfold add_vertex_with_predecessors
     simp only
     simp only [Bool.not_eq_true, ne_eq] at h
@@ -352,57 +339,58 @@ namespace PreGraph
       simp
       split
       · case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
-      · rw [Std.HashMap.getD_eq_fallback_of_contains_eq_false]
+      · rw [Std.HashMap.getD_eq_fallback]
         apply h.left
     · rw [Std.HashMap.getD_insert]
       simp only [beq_iff_eq]
       split
       · case isTrue eq => have h_right := h.right; rw [eq] at h_right; contradiction
-      · rw [Std.HashMap.getD_eq_fallback_of_contains_eq_false]
+      · rw [Std.HashMap.getD_eq_fallback]
         apply h.left
 
   theorem add_vertex_with_predecessors_still_complete (pg : PreGraph A) (v : A) (vs : List A) (pg_is_complete : pg.complete) : (pg.add_vertex_with_predecessors v vs).complete := by
-    unfold complete
-    unfold predecessors
+    simp [complete] at pg_is_complete
+    simp [complete, preds]
     intro a ha
-    rw [add_vertex_with_predecessors_contains_iff_contains_or_in_new_vertices] at ha
+    rw [mem_add_vertex_with_predecessors_iff_mem_or_in_new_vertices] at ha
     intro a' ha'
-    rw [add_vertex_with_predecessors_contains_iff_contains_or_in_new_vertices]
+    rw [mem_add_vertex_with_predecessors_iff_mem_or_in_new_vertices]
     cases ha with
-    | inl contains_and_eq =>
-      rw [add_vertex_with_predecessors_getD_semantics_1 pg v a _ contains_and_eq] at ha'
+    | inl mem_and_eq =>
+      rw [add_vertex_with_predecessors_getD_semantics_1 pg v a _ mem_and_eq] at ha'
       rw [List.mem_append] at ha'
       cases ha' with
       | inl ha' =>
         cases Decidable.em (a' = v) with
-        | inl hl => apply Or.inl; constructor; apply pg_is_complete; exact contains_and_eq.left; rw [contains_and_eq.right]; apply ha'; exact hl
-        | inr hr => apply Or.inr; apply Or.inl; constructor; apply pg_is_complete; exact contains_and_eq.left;  rw [contains_and_eq.right]; apply ha'; exact hr
+        | inl hl => simp [hl, mem_and_eq.1, ← mem_and_eq.2]
+        | inr hr => rw [mem_and_eq.2] at mem_and_eq
+                    simp [hr, pg_is_complete v mem_and_eq.1 a' ha']
       | inr ha' =>
         cases Decidable.em (a' = v) with
         | inl hl =>
-          cases Decidable.em (pg.contains a') with
+          cases Decidable.em (a' ∈ pg) with
           | inl hll => apply Or.inl; constructor; exact hll; exact hl
           | inr hlr => apply Or.inr; apply Or.inr; apply Or.inl; constructor; exact hlr; exact hl
         | inr hr =>
-          cases Decidable.em (pg.contains a') with
+          cases Decidable.em (a' ∈ pg) with
           | inl hrl => apply Or.inr; apply Or.inl; constructor; exact hrl; exact hr
           | inr hrr => apply Or.inr; apply Or.inr; apply Or.inr; constructor; exact hrr; constructor; exact hr; exact ha'
     | inr rest => cases rest with
-    | inl contains_and_neq =>
-      rw [add_vertex_with_predecessors_getD_semantics_2 pg v a _ contains_and_neq] at ha'
+    | inl mem_and_neq =>
+      rw [add_vertex_with_predecessors_getD_semantics_2 pg v a _ mem_and_neq] at ha'
       cases Decidable.em (a' = v) with
-      | inl hl => apply Or.inl; constructor; apply pg_is_complete; exact contains_and_neq.left; apply ha'; exact hl
-      | inr hr => apply Or.inr; apply Or.inl; constructor; apply pg_is_complete; exact contains_and_neq.left; apply ha'; exact hr
+      | inl hl => apply Or.inl; constructor; apply pg_is_complete; exact mem_and_neq.left; apply ha'; exact hl
+      | inr hr => apply Or.inr; apply Or.inl; constructor; apply pg_is_complete; exact mem_and_neq.left; apply ha'; exact hr
     | inr rest => cases rest with
-    | inl not_contains_and_eq =>
-      rw [add_vertex_with_predecessors_getD_semantics_3 pg v a _ not_contains_and_eq] at ha'
+    | inl not_mem_and_eq =>
+      rw [add_vertex_with_predecessors_getD_semantics_3 pg v a _ not_mem_and_eq] at ha'
       cases Decidable.em (a' = v) with
       | inl hl =>
-        cases Decidable.em (pg.contains a') with
+        cases Decidable.em (a' ∈ pg) with
         | inl hll => apply Or.inl; constructor; exact hll; exact hl
         | inr hlr => apply Or.inr; apply Or.inr; apply Or.inl; constructor; exact hlr; exact hl
       | inr hr =>
-        cases Decidable.em (pg.contains a') with
+        cases Decidable.em (a' ∈ pg) with
         | inl hrl => apply Or.inr; apply Or.inl; constructor; exact hrl; exact hr
         | inr hrr => apply Or.inr; apply Or.inr; apply Or.inr; constructor; exact hrr; constructor; exact hr; exact ha'
     | inr not_contains_and_neq =>
@@ -410,20 +398,20 @@ namespace PreGraph
       contradiction
 end PreGraph
 
-abbrev Graph (A: Type u) [DecidableEq A] [Hashable A] := { pg : PreGraph A // pg.complete }
+variable (A) in abbrev Graph := { pg : PreGraph A // pg.complete }
 
 namespace Graph
-  variable {A: Type u} [DecidableEq A] [Hashable A]
-
   def vertices (g : Graph A) : List A := g.val.vertices
-  def predecessors (g : Graph A) (a : A) : List A := g.val.predecessors a
+  def predecessors (g : Graph A) (a : A) : List A := g.val.preds a
 
   theorem complete (g : Graph A) : ∀ (a:A), a ∈ g.vertices →  ∀ (a':A), a' ∈ g.predecessors a → a' ∈ g.vertices := by
     intro a ha b hb
     unfold vertices
-    rw [PreGraph.in_vertices_iff_contains]
-    apply g.property
-    · rw [← PreGraph.in_vertices_iff_contains]
+    rw [PreGraph.in_vertices_iff_mem]
+    have := g.property
+    simp [PreGraph.complete] at this
+    apply this
+    · rw [← PreGraph.in_vertices_iff_mem]
       apply ha
     · unfold predecessors at hb
       apply hb
@@ -451,7 +439,7 @@ namespace Graph
       exact eq
     | true =>
       unfold vertices
-      rw [PreGraph.in_vertices_iff_contains]
+      rw [PreGraph.in_vertices_iff_mem]
       exact eq
 
   theorem mem_of_is_pred (G : Graph A) (a b : A) : b ∈ G.predecessors a -> b ∈ G.vertices := by


### PR DESCRIPTION
This PR allows us to write the graph definition a bit more succintly by:

1. Renaming `predecessors` to `pred`: I didn't find another way to shorten this line.
2. Using a single line for all type variables and type classes and only mark the type variables explicit in the definitions of `PreGraph`/`Graph`
3. Use a shorter definition for `complete` using `List.all`
4. Replace `contains` by `∈`: This leads to the most changes as this effects the proofs.